### PR TITLE
Do not copy ArrayBuffer in TransferArrayBuffer

### DIFF
--- a/build/replace-imports.js
+++ b/build/replace-imports.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const { createFilter } = require('rollup-pluginutils');
+
+module.exports = function replaceImports(options = {}) {
+  const filter = createFilter(options.include, options.exclude);
+  const imports = options.imports;
+  return {
+    resolveId(importee, importer) {
+      if (!importer || !filter(importer)) {
+        return undefined;
+      }
+      let replace;
+      const importeePath = path.resolve(path.dirname(importer), importee);
+      for (const { from, to } of imports) {
+        if (importeePath === from) {
+          replace = to;
+          break;
+        }
+      }
+      return replace;
+    }
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1675,9 +1675,9 @@
       "dev": true
     },
     "estree-walker": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
-      "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+      "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
       "dev": true
     },
     "esutils": {
@@ -3901,12 +3901,12 @@
       }
     },
     "rollup-pluginutils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
-      "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz",
+      "integrity": "sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==",
       "dev": true,
       "requires": {
-        "estree-walker": "^0.3.0",
+        "estree-walker": "^0.5.2",
         "micromatch": "^2.3.11"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "types": "types/polyfill.d.ts",
   "scripts": {
     "test": "node --expose_gc run-web-platform-tests.js",
-    "lint": "eslint \"*.js\" \"src/**/*.js\"",
+    "lint": "eslint \"*.js\" \"build/**/*.js\" \"src/**/*.js\"",
     "build": "rollup -c",
     "prebuild": "git submodule update --init --recursive",
     "prepare": "npm run build"
@@ -56,6 +56,7 @@
     "rollup-plugin-inject": "^2.2.0",
     "rollup-plugin-strip": "^1.2.0",
     "rollup-plugin-terser": "^3.0.0",
+    "rollup-pluginutils": "^2.3.3",
     "typescript": "^3.2.2",
     "wpt-runner": "^2.7.0"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,7 @@ const rollupBabel = require('rollup-plugin-babel');
 const rollupInject = require('rollup-plugin-inject');
 const rollupStrip = require('rollup-plugin-strip');
 const { terser: rollupTerser } = require('rollup-plugin-terser');
+const replaceImports = require('./build/replace-imports');
 
 function buildConfig(entry, { esm = false, minify = false, es6 = false } = {}) {
   const outname = `${entry}${es6 ? '.es6' : ''}`;
@@ -27,8 +28,15 @@ function buildConfig(entry, { esm = false, minify = false, es6 = false } = {}) {
       } : undefined
     ].filter(Boolean),
     plugins: [
-      rollupCommonJS({
+      replaceImports({
         include: 'spec/reference-implementation/lib/*.js',
+        imports: [{
+          from: path.resolve(__dirname, './spec/reference-implementation/lib/helpers.js'),
+          to: path.resolve(__dirname, './src/stub/helpers.js')
+        }]
+      }),
+      rollupCommonJS({
+        include: ['spec/reference-implementation/lib/*.js'],
         sourceMap: true
       }),
       rollupInject({

--- a/src/stub/helpers.js
+++ b/src/stub/helpers.js
@@ -9,11 +9,19 @@ export {
   CreateAlgorithmFromUnderlyingMethod,
   InvokeOrNoop,
   PromiseCall,
-  TransferArrayBuffer,
-  IsDetachedBuffer,
   ValidateAndNormalizeHighWaterMark,
   MakeSizeAlgorithmFromSizeFunction,
   PerformPromiseThen,
   WaitForAll,
   WaitForAllPromise
 } from '../../spec/reference-implementation/lib/helpers';
+
+// Not implemented correctly
+export function TransferArrayBuffer(O) {
+  return O;
+}
+
+// Not implemented correctly
+export function IsDetachedBuffer(O) { // eslint-disable-line no-unused-vars
+  return false;
+}

--- a/src/stub/helpers.js
+++ b/src/stub/helpers.js
@@ -1,0 +1,19 @@
+export {
+  typeIsObject,
+  createDataProperty,
+  createArrayFromList,
+  ArrayBufferCopy,
+  IsFiniteNonNegativeNumber,
+  IsNonNegativeNumber,
+  Call,
+  CreateAlgorithmFromUnderlyingMethod,
+  InvokeOrNoop,
+  PromiseCall,
+  TransferArrayBuffer,
+  IsDetachedBuffer,
+  ValidateAndNormalizeHighWaterMark,
+  MakeSizeAlgorithmFromSizeFunction,
+  PerformPromiseThen,
+  WaitForAll,
+  WaitForAllPromise
+} from '../../spec/reference-implementation/lib/helpers';


### PR DESCRIPTION
In the reference implementation, `TransferArrayBuffer` copies the given `ArrayBuffer` with `O.slice()` in order to create a separate "transferred" version. This is fine for testing purposes but unacceptable for production use, as it defeats the purpose of transferring control *without copying the data*.

This PR replaces `lib/helpers.js` with a stub where the `TransferArrayBuffer` and `IsDetachedArrayBuffer` helper functions are replaced with dummy implementations. This causes (expected) test failures in [WPT `readable-byte-streams/detached-buffers.any.js`](https://github.com/web-platform-tests/wpt/blob/4dbc8a0d7b1b1c032aaddc2579ec7239ad565127/streams/readable-byte-streams/detached-buffers.any.js), so we now exclude this particular file from the test suite.

Fixes #3