### PR TITLE
Fix memory leak when using streams in a microtask loop in Node.js

### DIFF
--- a/src/lib/readable-stream.js
+++ b/src/lib/readable-stream.js
@@ -928,7 +928,6 @@ function ReadableStreamReaderGenericInitialize(reader, stream) {
     assert(stream._state === 'errored');
 
     defaultReaderClosedPromiseInitializeAsRejected(reader, stream._storedError);
-    reader._closedPromise.catch(() => {});
   }
 }
 

--- a/src/lib/readable-stream.js
+++ b/src/lib/readable-stream.js
@@ -689,7 +689,6 @@ function ReadableStreamError(stream, e) {
   }
 
   defaultReaderClosedPromiseReject(reader, e);
-  reader._closedPromise.catch(() => {});
 }
 
 function ReadableStreamFulfillReadIntoRequest(stream, chunk, done) {
@@ -955,7 +954,6 @@ function ReadableStreamReaderGenericRelease(reader) {
       reader,
       new TypeError('Reader was released and can no longer be used to monitor the stream\'s closedness'));
   }
-  reader._closedPromise.catch(() => {});
 
   reader._ownerReadableStream._reader = undefined;
   reader._ownerReadableStream = undefined;
@@ -2101,21 +2099,20 @@ function defaultReaderClosedPromiseInitialize(reader) {
 }
 
 function defaultReaderClosedPromiseInitializeAsRejected(reader, reason) {
-  reader._closedPromise = Promise.reject(reason);
-  reader._closedPromise_resolve = undefined;
-  reader._closedPromise_reject = undefined;
+  defaultReaderClosedPromiseInitialize(reader);
+  defaultReaderClosedPromiseReject(reader, reason);
 }
 
 function defaultReaderClosedPromiseInitializeAsResolved(reader) {
-  reader._closedPromise = Promise.resolve(undefined);
-  reader._closedPromise_resolve = undefined;
-  reader._closedPromise_reject = undefined;
+  defaultReaderClosedPromiseInitialize(reader);
+  defaultReaderClosedPromiseResolve(reader);
 }
 
 function defaultReaderClosedPromiseReject(reader, reason) {
   assert(reader._closedPromise_resolve !== undefined);
   assert(reader._closedPromise_reject !== undefined);
 
+  reader._closedPromise.catch(() => {});
   reader._closedPromise_reject(reason);
   reader._closedPromise_resolve = undefined;
   reader._closedPromise_reject = undefined;
@@ -2125,7 +2122,7 @@ function defaultReaderClosedPromiseResetToRejected(reader, reason) {
   assert(reader._closedPromise_resolve === undefined);
   assert(reader._closedPromise_reject === undefined);
 
-  reader._closedPromise = Promise.reject(reason);
+  defaultReaderClosedPromiseInitializeAsRejected(reader, reason);
 }
 
 function defaultReaderClosedPromiseResolve(reader) {

--- a/src/lib/writable-stream.js
+++ b/src/lib/writable-stream.js
@@ -1022,6 +1022,7 @@ function defaultWriterClosedPromiseResolve(writer) {
 }
 
 function defaultWriterReadyPromiseInitialize(writer) {
+  verbose('defaultWriterReadyPromiseInitialize()');
   writer._readyPromise = new Promise((resolve, reject) => {
     writer._readyPromise_resolve = resolve;
     writer._readyPromise_reject = reject;
@@ -1030,16 +1031,19 @@ function defaultWriterReadyPromiseInitialize(writer) {
 }
 
 function defaultWriterReadyPromiseInitializeAsRejected(writer, reason) {
+  verbose('defaultWriterReadyPromiseInitializeAsRejected(writer, %o)', reason);
   defaultWriterReadyPromiseInitialize(writer);
   defaultWriterReadyPromiseReject(writer, reason);
 }
 
 function defaultWriterReadyPromiseInitializeAsResolved(writer) {
+  verbose('defaultWriterReadyPromiseInitializeAsResolved()');
   defaultWriterReadyPromiseInitialize(writer);
   defaultWriterReadyPromiseResolve(writer);
 }
 
 function defaultWriterReadyPromiseReject(writer, reason) {
+  verbose('defaultWriterReadyPromiseReject(writer, %o)', reason);
   assert(writer._readyPromise_resolve !== undefined);
   assert(writer._readyPromise_reject !== undefined);
 
@@ -1051,6 +1055,7 @@ function defaultWriterReadyPromiseReject(writer, reason) {
 }
 
 function defaultWriterReadyPromiseReset(writer) {
+  verbose('defaultWriterReadyPromiseReset()');
   assert(writer._readyPromise_resolve === undefined);
   assert(writer._readyPromise_reject === undefined);
 
@@ -1058,6 +1063,7 @@ function defaultWriterReadyPromiseReset(writer) {
 }
 
 function defaultWriterReadyPromiseResetToRejected(writer, reason) {
+  verbose('defaultWriterReadyPromiseResetToRejected(writer, %o)', reason);
   assert(writer._readyPromise_resolve === undefined);
   assert(writer._readyPromise_reject === undefined);
 
@@ -1065,6 +1071,7 @@ function defaultWriterReadyPromiseResetToRejected(writer, reason) {
 }
 
 function defaultWriterReadyPromiseResolve(writer) {
+  verbose('defaultWriterReadyPromiseResolve()');
   assert(writer._readyPromise_resolve !== undefined);
   assert(writer._readyPromise_reject !== undefined);
 


### PR DESCRIPTION
Hi @MattiasBuelens! First of all, thanks for all your work on this polyfill.

In Node.js, when using streams in a microtask loop that never finishes (e.g. `while (true) { await ... }`, or on a server that's constantly receiving events) there's a memory leak.

AFAIU, it comes from an internal list of unhandled promise rejections in Node, which retains promises created by this library, which in turn retains the closure in which they were created, which in turn retains the data that the stream was created from in some cases.
https://github.com/nodejs/node/blob/d18b0a01320e392e48f0c475effd8d4db2bb71a8/lib/internal/process/promises.js#L62

Node cleans up this list at the end of every macrotask loop tick, but if there are always new microtasks coming in it never gets to that.
https://github.com/nodejs/node/blob/d18b0a01320e392e48f0c475effd8d4db2bb71a8/lib/internal/process/next_tick.js#L82
(I believe this is more or less as per spec, as unhandled rejections are supposed to be thrown as a macrotask, not a microtask. There's probably nothing preventing Node from cleaning up _handled_ rejections in the microtask loop, though, so it could be argued that this is a Node bug.)

As `promiseRejectHandler` is called synchronously, even `Promise.reject(reason).catch(() => {})` adds to this list.
This PR essentially replaces that by:
```js
let reject;
let promise = new Promise((res, rej) => {
  reject = rej;
});
promise.catch(() => {});
reject(reason);
return promise;
```

which makes sure that `promiseRejectHandler` is never called, by catching the promise before it's rejected.

---

Chrome doesn't seem to leak memory, neither with its built-in streams (which use the internal `v8.markPromiseAsHandled` function) nor with this polyfill, so maybe this should be fixed in Node as well, but I'd rather fix it here for now and not have to wait for a new Node release :)

Firefox seems to also have a memory leak that is similar to this but not exactly the same - even with this patch, and even when running a _macrotask_ loop (e.g. with `setTimeout`), it still leaks memory. A memory snapshot points to the same sort of retention chain, with the addition that each Promise points to the previous one (PromiseReactionRecord -> Promise -> (...) -> PromiseReactionRecord -> Promise -> Function -> LexicalEnvironment).