### PR TITLE
Add @@asyncIterator to ReadableStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 🚀 Add `@@asyncIterator` to `ReadableStream` ([#11](https://github.com/MattiasBuelens/web-streams-polyfill/pull/11))
+* 🚀 Add `polyfill/es2018` and `ponyfill/es2018` variants ([#11](https://github.com/MattiasBuelens/web-streams-polyfill/pull/11))
+* 👓 Align with [spec version `bf2cac8a52`](https://github.com/whatwg/streams/tree/bf2cac8a52664df3e6da7a48755890e87b00953a/) ([#11](https://github.com/MattiasBuelens/web-streams-polyfill/pull/11))
+
 ## v0.3.1 (2019-02-25)
 
 * 🐛 Fix ES5 build target ([#9](https://github.com/MattiasBuelens/web-streams-polyfill/pull/9))

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Web Streams, based on the WHATWG spec reference implementation.
 
 ## Usage
 
-This library comes in four variants:
+This library comes in multiple variants:
 * `@mattiasbuelens/web-streams-polyfill`: a polyfill that replaces the native stream implementations.
   Recommended for use in web apps through a `<script>` tag.
 * `@mattiasbuelens/web-streams-polyfill/es6`: a polyfill targeting ES2015+ environments.
@@ -24,6 +24,9 @@ This library comes in four variants:
   Recommended for use in Node applications or web libraries.
 * `@mattiasbuelens/web-streams-polyfill/ponyfill/es6`: a ponyfill targeting ES2015+ environments.
   Recommended for use in modern Node applications, or in web libraries targeting modern browsers.
+* `@mattiasbuelens/web-streams-polyfill/es2018`: a polyfill targeting ES2018+ environments.
+  Required for [`ReadableStream.prototype[Symbol.asyncIterator]()`][rs-asynciterator].
+* `@mattiasbuelens/web-streams-polyfill/ponyfill/es2018`: a ponyfill targeting ES2015+ environments.
 
 Each variant also includes TypeScript type definitions, compatible with the DOM type definitions for streams included in TypeScript.
 
@@ -58,6 +61,8 @@ If you need to support older browsers or Node versions that do not have a native
 
 The `polyfill/es6` and `ponyfill/es6` variants work in any ES2015-compatible environment.
 
+The `polyfill/es2018` and `ponyfill/es2018` variants work in any ES2018-compatible environment.
+
 ### Compliance
 
 The polyfill implements [version `1116de06e9` (29 Nov 2018)](https://streams.spec.whatwg.org/commit-snapshots/1116de06e94bf4406c60b1e766111dfd8bc7bfcd/) of the streams specification.
@@ -74,6 +79,7 @@ Thanks to these people for their work on [the original polyfill][creatorrr-polyf
 [spec]: https://streams.spec.whatwg.org
 [ref-impl]: https://github.com/whatwg/streams
 [ponyfill]: https://github.com/sindresorhus/ponyfill
+[rs-asynciterator]: https://streams.spec.whatwg.org/#rs-asynciterator
 [promise-support]: https://kangax.github.io/compat-table/es6/#test-Promise
 [promise-polyfill]: https://www.npmjs.com/package/promise-polyfill
 [creatorrr-polyfill]: https://github.com/creatorrr/web-streams-polyfill

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ This library comes in multiple variants:
   Recommended for use in web apps through a `<script>` tag.
 * `@mattiasbuelens/web-streams-polyfill/es6`: a polyfill targeting ES2015+ environments.
   Recommended for use in web apps targeting modern browsers through a `<script>` tag.
+* `@mattiasbuelens/web-streams-polyfill/es2018`: a polyfill targeting ES2018+ environments.
 * `@mattiasbuelens/web-streams-polyfill/ponyfill`: a [ponyfill] that provides
   the stream implementations without replacing any globals.
   Recommended for use in Node applications or web libraries.
 * `@mattiasbuelens/web-streams-polyfill/ponyfill/es6`: a ponyfill targeting ES2015+ environments.
   Recommended for use in modern Node applications, or in web libraries targeting modern browsers.
-* `@mattiasbuelens/web-streams-polyfill/es2018`: a polyfill targeting ES2018+ environments.
   Required for [`ReadableStream.prototype[Symbol.asyncIterator]()`][rs-asynciterator].
-* `@mattiasbuelens/web-streams-polyfill/ponyfill/es2018`: a ponyfill targeting ES2015+ environments.
+* `@mattiasbuelens/web-streams-polyfill/ponyfill/es2018`: a ponyfill targeting ES2018+ environments.
 
 Each variant also includes TypeScript type definitions, compatible with the DOM type definitions for streams included in TypeScript.
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,18 @@ Web Streams, based on the WHATWG spec reference implementation.
 
 This library comes in multiple variants:
 * `@mattiasbuelens/web-streams-polyfill`: a polyfill that replaces the native stream implementations.
-  Recommended for use in web apps through a `<script>` tag.
+  Recommended for use in web apps supporting older browsers through a `<script>` tag.
 * `@mattiasbuelens/web-streams-polyfill/es6`: a polyfill targeting ES2015+ environments.
-  Recommended for use in web apps targeting modern browsers through a `<script>` tag.
+  Recommended for use in web apps supporting modern browsers through a `<script>` tag.
 * `@mattiasbuelens/web-streams-polyfill/es2018`: a polyfill targeting ES2018+ environments.
+  Required for [`ReadableStream` async iterable support][rs-asynciterator].
 * `@mattiasbuelens/web-streams-polyfill/ponyfill`: a [ponyfill] that provides
   the stream implementations without replacing any globals.
-  Recommended for use in Node applications or web libraries.
+  Recommended for use in legacy Node applications, or in web libraries supporting older browsers.
 * `@mattiasbuelens/web-streams-polyfill/ponyfill/es6`: a ponyfill targeting ES2015+ environments.
-  Recommended for use in modern Node applications, or in web libraries targeting modern browsers.
-  Required for [`ReadableStream.prototype[Symbol.asyncIterator]()`][rs-asynciterator].
+  Recommended for use in Node 6+ applications, or in web libraries supporting modern browsers.
 * `@mattiasbuelens/web-streams-polyfill/ponyfill/es2018`: a ponyfill targeting ES2018+ environments.
+  Recommended for use in Node 10+ applications.
 
 Each variant also includes TypeScript type definitions, compatible with the DOM type definitions for streams included in TypeScript.
 
@@ -65,7 +66,7 @@ The `polyfill/es2018` and `ponyfill/es2018` variants work in any ES2018-compatib
 
 ### Compliance
 
-The polyfill implements [version `1116de06e9` (29 Nov 2018)](https://streams.spec.whatwg.org/commit-snapshots/1116de06e94bf4406c60b1e766111dfd8bc7bfcd/) of the streams specification.
+The polyfill implements [version `bf2cac8` (6 Feb 2019)](https://streams.spec.whatwg.org/commit-snapshots/bf2cac8a52664df3e6da7a48755890e87b00953a/) of the streams specification.
 
 The type definitions are compatible with the built-in stream types of TypeScript 3.3.
 

--- a/es2018/package.json
+++ b/es2018/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@mattiasbuelens/web-streams-polyfill-es2018",
+  "main": "../dist/polyfill.es2018",
+  "browser": "../dist/polyfill.es2018.min.js",
+  "module": "../dist/polyfill.es2018.mjs",
+  "types": "../dist/types/polyfill.d.ts"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,18 +31,19 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.4.tgz",
-      "integrity": "sha512-Zl8dGvAcEmadgs1tmSPcvwzO1YRsz38bVJQvH1RvRqSR9/5n61Q1ktcDL0ht3FXWR+ZpVmXVwN1LuH4Ax23NsA==",
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.0.tgz",
+      "integrity": "sha512-D5Rt+HXgEywr3RQJcGlZUCTCx1qVbCZpVk3/tOOA6spLNZdGm8BU+zRgdRYDoF1pO3RuXLxADzMrF903JlQXqg==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.3.0.tgz",
-      "integrity": "sha512-s+vjO9+PvYS2A6FnQC/imyEDOkrEKIzSpPf2OEGnkKqa5+1d0cuXgCi/oROtuBht2/u/iK22nrYcO/Ei4R8F/g==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.4.2.tgz",
+      "integrity": "sha512-6WInypy/cK4rM1dirKbD5p7iFW28DbSRKT/+PGn+DYzBWEvHq5KnZAqQ5cX25JBc0qMkFxJNxNfBbFXJyyzVcw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/parser": "1.3.0",
+        "@typescript-eslint/parser": "1.4.2",
+        "@typescript-eslint/typescript-estree": "1.4.2",
         "requireindex": "^1.2.0",
         "tsutils": "^3.7.0"
       },
@@ -59,20 +60,20 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.3.0.tgz",
-      "integrity": "sha512-Q5cz9nyEQyRrtItRElvQXdNs0Xja1xvOdphDQR7N6MqUdi4juWVNxHKypdHQCx9OcEBev6pWHOda8lwg/2W9/g==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.4.2.tgz",
+      "integrity": "sha512-OqLkY9295DXXaWToItUv3olO2//rmzh6Th6Sc7YjFFEpEuennsm5zhygLLvHZjPxPlzrQgE8UDaOPurDylaUuw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "1.3.0",
+        "@typescript-eslint/typescript-estree": "1.4.2",
         "eslint-scope": "^4.0.0",
         "eslint-visitor-keys": "^1.0.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.3.0.tgz",
-      "integrity": "sha512-h6UxHSmBUopFcxHg/eryrA+GwHMbh7PxotMbkq9p2f3nX60CKm5Zc0VN8krBD3IS5KqsK0iOz24VpEWrP+JZ2Q==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.4.2.tgz",
+      "integrity": "sha512-wKgi/w6k1v3R4b6oDc20cRWro2gBzp0wn6CAeYC8ExJMfvXMfiaXzw2tT9ilxdONaVWMCk7B9fMdjos7bF/CWw==",
       "dev": true,
       "requires": {
         "lodash.unescape": "4.0.1",
@@ -86,9 +87,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-      "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
       "dev": true
     },
     "acorn-globals": {
@@ -114,9 +115,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-      "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -471,9 +472,9 @@
       "dev": true
     },
     "camelcase": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+      "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
       "dev": true
     },
     "caseless": {
@@ -638,15 +639,15 @@
       }
     },
     "cssom": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-      "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
       "dev": true
     },
     "cssstyle": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
-      "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz",
+      "integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
       "dev": true,
       "requires": {
         "cssom": "0.3.x"
@@ -802,9 +803,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
-      "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+      "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
       "dev": true,
       "requires": {
         "esprima": "^3.1.3",
@@ -830,9 +831,9 @@
       }
     },
     "eslint": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.14.1.tgz",
-      "integrity": "sha512-CyUMbmsjxedx8B0mr79mNOqetvkbij/zrXnFeK2zc3pGRn3/tibjiNAv/3UxFEyfMDjh+ZqTrJrEGBFiGfD5Og==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.1.tgz",
+      "integrity": "sha512-NTcm6vQ+PTgN3UBsALw5BMhgO6i5EpIjQF/Xb5tIh3sk9QhrFafujUOczGz4J24JBlzWclSB9Vmx8d+9Z6bFCg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -841,7 +842,7 @@
         "cross-spawn": "^6.0.5",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
-        "eslint-scope": "^4.0.0",
+        "eslint-scope": "^4.0.2",
         "eslint-utils": "^1.3.1",
         "eslint-visitor-keys": "^1.0.0",
         "espree": "^5.0.1",
@@ -873,18 +874,6 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.9.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-          "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "semver": {
           "version": "5.6.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -894,9 +883,9 @@
       }
     },
     "eslint-scope": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
-      "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",
+      "integrity": "sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
@@ -924,14 +913,6 @@
         "acorn": "^6.0.7",
         "acorn-jsx": "^5.0.0",
         "eslint-visitor-keys": "^1.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-          "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
-          "dev": true
-        }
       }
     },
     "esprima": {
@@ -1336,9 +1317,9 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true,
       "optional": true
     },
@@ -1502,18 +1483,18 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
+          "integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -1722,9 +1703,9 @@
       "dev": true
     },
     "jsdom": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-13.1.0.tgz",
-      "integrity": "sha512-C2Kp0qNuopw0smXFaHeayvharqF3kkcNqlcIlSX71+3XrsOFwkEPLt/9f5JksMmaul2JZYIQuY+WTpqHpQQcLg==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-13.2.0.tgz",
+      "integrity": "sha512-cG1NtMWO9hWpqRNRR3dSvEQa8bFI6iLlqU2x4kwX51FQjp0qus8T9aBaAO6iGp3DeBrhdwuKxckknohkmfvsFw==",
       "dev": true,
       "requires": {
         "abab": "^2.0.0",
@@ -1742,7 +1723,7 @@
         "pn": "^1.1.0",
         "request": "^2.88.0",
         "request-promise-native": "^1.0.5",
-        "saxes": "^3.1.4",
+        "saxes": "^3.1.5",
         "symbol-tree": "^3.2.2",
         "tough-cookie": "^2.5.0",
         "w3c-hr-time": "^1.0.1",
@@ -1888,14 +1869,14 @@
       }
     },
     "mem": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
-      "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+      "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
       "dev": true,
       "requires": {
         "map-age-cleaner": "^0.1.1",
         "mimic-fn": "^1.0.0",
-        "p-is-promise": "^1.1.0"
+        "p-is-promise": "^2.0.0"
       }
     },
     "merge-stream": {
@@ -1935,18 +1916,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "~1.38.0"
       }
     },
     "mimic-fn": {
@@ -2065,9 +2046,9 @@
       "dev": true
     },
     "nwsapi": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-      "integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.1.tgz",
+      "integrity": "sha512-T5GaA1J/d34AC8mkrFD2O0DR17kwJ702ZOtJOsS8RpbsQZVOC2/xYFb1i/cw+xdM54JIlMuojjDOYct8GIWtwg==",
       "dev": true
     },
     "oauth-sign": {
@@ -2187,15 +2168,15 @@
       "dev": true
     },
     "p-is-promise": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
       "dev": true
     },
     "p-limit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-      "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -2442,23 +2423,23 @@
       }
     },
     "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
       "dev": true,
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "^4.17.11"
       }
     },
     "request-promise-native": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
       "dev": true,
       "requires": {
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "^1.1.0",
-        "tough-cookie": ">=2.3.3"
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "require-directory": {
@@ -2526,28 +2507,20 @@
       }
     },
     "rollup": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.2.1.tgz",
-      "integrity": "sha512-rFf7m2MHwjSYjSCFdA7ckGluMcQRcC3dKn6uAWYrk/6wnUrdQhJJruumkk5IV/3KMdmuc9qORmTu1VPBa2Ii8w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.6.0.tgz",
+      "integrity": "sha512-qu9iWyuiOxAuBM8cAwLuqPclYdarIpayrkfQB7aTGTiyYPbvx+qVF33sIznfq4bxZCiytQux/FvZieUBAXivCw==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "*",
-        "acorn": "^6.1.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-          "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
-          "dev": true
-        }
+        "@types/node": "^11.9.5",
+        "acorn": "^6.1.1"
       }
     },
     "rollup-plugin-dts": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-0.12.0.tgz",
-      "integrity": "sha512-q4suZwWNNcOp/FOOdzJgpbcDfi96Uxbq+hZAv9Kn3qogYdmUSIiNY1zpFPNgF2AVqnn+Cryrme06zwdSCLjsBQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-0.13.0.tgz",
+      "integrity": "sha512-aIirfr+UuQt3FRF/R33WxxySEhQJth32Ld+g4mJyyHhJjzZ2drNv0dzq5zO0d/fo+0CBRQHM1qsHVc3SMDHDWg==",
       "dev": true
     },
     "rollup-plugin-inject": {
@@ -2651,9 +2624,9 @@
       "dev": true
     },
     "saxes": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.4.tgz",
-      "integrity": "sha512-GVZmLJnkS4Vl8Pe9o4nc5ALZ615VOVxCmea8Cs0l+8GZw3RQ5XGOSUomIUfuZuk4Todo44v4y+HY1EATkDDiZg==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.9.tgz",
+      "integrity": "sha512-FZeKhJglhJHk7eWG5YM0z46VHmI3KJpMBAQm3xa9meDvd+wevB5GuBB0wc0exPInZiBBHqi00DbS8AcvCGCFMw==",
       "dev": true,
       "requires": {
         "xmlchars": "^1.3.1"
@@ -2919,9 +2892,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
-      "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -3043,42 +3016,30 @@
         "string-width": "^3.0.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.9.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-          "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
         "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "string-width": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
-          "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
+          "integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -3244,9 +3205,9 @@
       }
     },
     "typescript": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz",
-      "integrity": "sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==",
+      "version": "3.3.3333",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
       "dev": true
     },
     "union-value": {
@@ -3442,9 +3403,9 @@
       "dev": true
     },
     "wpt-runner": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/wpt-runner/-/wpt-runner-2.7.0.tgz",
-      "integrity": "sha512-4jqhCwa1Hxp6SHQLrmEmRdbBzSBVBYn3vk/kvFJliY+EPy7Gf/szja4/t65R2S7gf3b4PSaA+N647wrL+Po9yg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/wpt-runner/-/wpt-runner-2.7.1.tgz",
+      "integrity": "sha512-6G/lVZY3Cz6WJ2loyF4UI9VESiPFD8nDf3DBcoR0sF7wcTclLIh1at/khO3NyZtgsQi8BqY9MiguDVa1dZXkVA==",
       "dev": true,
       "requires": {
         "colors": "^1.3.2",
@@ -3517,9 +3478,9 @@
       }
     },
     "ws": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
-      "integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.0.tgz",
+      "integrity": "sha512-deZYUNlt2O4buFCa3t5bKLf8A7FPP/TVjwOeVNpw818Ma5nk4MLXls2eoEGS39o8119QIYxTrTDoPQ5B/gTD6w==",
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "files": [
     "dist",
     "es6",
+    "es2018",
     "ponyfill"
   ],
   "engines": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "types": "dist/types/polyfill.d.ts",
   "scripts": {
     "test": "npm run test:types && npm run test:wpt",
-    "test:wpt": "node --expose_gc run-web-platform-tests.js",
+    "test:wpt": "node --expose_gc ./test/run-web-platform-tests.js",
     "pretest:wpt": "git submodule update --init --recursive",
     "test:types": "tsc -p ./test/types/tsconfig.json",
     "lint": "eslint \"src/**/*.ts\"",

--- a/package.json
+++ b/package.json
@@ -45,15 +45,15 @@
   },
   "homepage": "https://github.com/MattiasBuelens/web-streams-polyfill#readme",
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^1.3.0",
-    "eslint": "^5.14.1",
+    "@typescript-eslint/eslint-plugin": "^1.4.2",
+    "eslint": "^5.15.1",
     "micromatch": "^3.1.10",
-    "rollup": "^1.2.1",
-    "rollup-plugin-dts": "^0.12.0",
+    "rollup": "^1.6.0",
+    "rollup-plugin-dts": "^0.13.0",
     "rollup-plugin-inject": "^2.2.0",
     "rollup-plugin-strip": "^1.2.1",
     "rollup-plugin-terser": "^4.0.4",
     "typescript": "^3.3.3",
-    "wpt-runner": "^2.7.0"
+    "wpt-runner": "^2.7.1"
   }
 }

--- a/ponyfill/es2018/package.json
+++ b/ponyfill/es2018/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@mattiasbuelens/web-streams-ponyfill-es2018",
+  "main": "../../dist/ponyfill.es2018",
+  "module": "../../dist/ponyfill.es2018.mjs",
+  "types": "../../dist/types/polyfill.d.ts"
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,7 +29,7 @@ function buildConfig(entry, { esm = false, minify = false, es6 = false } = {}) {
       rollupDts.js({
         tsconfig: 'src/tsconfig.json',
         compilerOptions: {
-          target: es6 ? ts.ScriptTarget.ES2015 : ts.ScriptTarget.ES5
+          // target: es6 ? ts.ScriptTarget.ES2015 : ts.ScriptTarget.ES5 // FIXME
         }
       }),
       rollupInject({
@@ -39,11 +39,12 @@ function buildConfig(entry, { esm = false, minify = false, es6 = false } = {}) {
           Symbol: path.resolve(__dirname, './src/stub/symbol.ts')
         }
       }),
-      rollupStrip({
-        include: 'src/**/*.ts',
-        functions: ['assert', 'debug', 'verbose'],
-        sourceMap: true
-      }),
+      // FIXME
+      // rollupStrip({
+      //   include: 'src/**/*.ts',
+      //   functions: ['assert', 'debug', 'verbose'],
+      //   sourceMap: true
+      // }),
       minify ? rollupTerser({
         keep_classnames: true, // needed for WPT
         mangle: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,8 +6,8 @@ const rollupInject = require('rollup-plugin-inject');
 const rollupStrip = require('rollup-plugin-strip');
 const { terser: rollupTerser } = require('rollup-plugin-terser');
 
-function buildConfig(entry, { esm = false, minify = false, es6 = false } = {}) {
-  const outname = `${entry}${es6 ? '.es6' : ''}`;
+function buildConfig(entry, { esm = false, minify = false, target = 'es5' } = {}) {
+  const outname = `${entry}${target === 'es5' ? '' : `.${target}`}`;
   return {
     input: `src/${entry}.ts`,
     output: [
@@ -27,10 +27,7 @@ function buildConfig(entry, { esm = false, minify = false, es6 = false } = {}) {
     ].filter(Boolean),
     plugins: [
       rollupDts.js({
-        tsconfig: 'src/tsconfig.json',
-        compilerOptions: {
-          // target: es6 ? ts.ScriptTarget.ES2015 : ts.ScriptTarget.ES5 // FIXME
-        }
+        tsconfig: `src/tsconfig${target === 'es5' ? '' : `-${target}`}.json`
       }),
       rollupInject({
         include: 'src/**/*.ts',
@@ -64,10 +61,10 @@ module.exports = [
   buildConfig('polyfill', { esm: true }),
   buildConfig('polyfill', { minify: true }),
   // polyfill/es6
-  buildConfig('polyfill', { es6: true, esm: true }),
-  buildConfig('polyfill', { es6: true, minify: true }),
+  buildConfig('polyfill', { target: 'es6', esm: true }),
+  buildConfig('polyfill', { target: 'es6', minify: true }),
   // ponyfill
   buildConfig('ponyfill', { esm: true }),
   // ponyfill/es6
-  buildConfig('ponyfill', { es6: true, esm: true })
+  buildConfig('ponyfill', { target: 'es6', esm: true })
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -63,8 +63,13 @@ module.exports = [
   // polyfill/es6
   buildConfig('polyfill', { target: 'es6', esm: true }),
   buildConfig('polyfill', { target: 'es6', minify: true }),
+  // polyfill/es2018
+  buildConfig('polyfill', { target: 'es2018', esm: true }),
+  buildConfig('polyfill', { target: 'es2018', minify: true }),
   // ponyfill
   buildConfig('ponyfill', { esm: true }),
   // ponyfill/es6
-  buildConfig('ponyfill', { target: 'es6', esm: true })
+  buildConfig('ponyfill', { target: 'es6', esm: true }),
+  // ponyfill/es2018
+  buildConfig('ponyfill', { target: 'es2018', esm: true })
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,12 +36,11 @@ function buildConfig(entry, { esm = false, minify = false, target = 'es5' } = {}
           Symbol: path.resolve(__dirname, './src/stub/symbol.ts')
         }
       }),
-      // FIXME
-      // rollupStrip({
-      //   include: 'src/**/*.ts',
-      //   functions: ['assert', 'debug', 'verbose'],
-      //   sourceMap: true
-      // }),
+      rollupStrip({
+        include: 'src/**/*.ts',
+        functions: ['assert', 'debug', 'verbose'],
+        sourceMap: true
+      }),
       minify ? rollupTerser({
         keep_classnames: true, // needed for WPT
         mangle: {

--- a/run-web-platform-tests.js
+++ b/run-web-platform-tests.js
@@ -28,7 +28,7 @@ main().catch(e => {
 });
 
 async function main() {
-  const entryPath = path.resolve(__dirname, 'dist/polyfill.es6.min.js');
+  const entryPath = path.resolve(__dirname, 'dist/polyfill.es2018.min.js');
   const testsPath = path.resolve(__dirname, 'test/web-platform-tests/streams');
 
   const includeGlobs = process.argv.length >= 3 ? process.argv.slice(2) : ['**/*.html'];

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -236,7 +236,7 @@ class ReadableStream<R = any> {
     return createArrayFromList(branches);
   }
 
-  getIterator({ preventCancel = false }: { preventCancel?: boolean } = {}): ReadableStreamAsyncIterator<R> {
+  getIterator({ preventCancel }: { preventCancel?: boolean } = {}): ReadableStreamAsyncIterator<R> {
     if (IsReadableStream(this) === false) {
       throw streamBrandCheckException('getIterator');
     }

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -315,12 +315,14 @@ if (AsyncIteratorPrototype !== undefined) {
 Object.defineProperty(ReadableStreamAsyncIteratorPrototype, 'next', { enumerable: false });
 Object.defineProperty(ReadableStreamAsyncIteratorPrototype, 'return', { enumerable: false });
 
-Object.defineProperty(ReadableStream.prototype, Symbol.asyncIterator, {
-  value: ReadableStream.prototype.getIterator,
-  enumerable: false,
-  writable: true,
-  configurable: true
-});
+if (typeof Symbol.asyncIterator === 'symbol') {
+  Object.defineProperty(ReadableStream.prototype, Symbol.asyncIterator, {
+    value: ReadableStream.prototype.getIterator,
+    enumerable: false,
+    writable: true,
+    configurable: true
+  });
+}
 
 export {
   CreateReadableByteStream,

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -30,6 +30,7 @@ import {
   WritableStreamDefaultWriterWrite
 } from './writable-stream';
 import NumberIsInteger from '../stub/number-isinteger';
+import { AsyncIteratorPrototype } from '@target/stub/async-iterator-prototype';
 
 const CancelSteps = Symbol('[[CancelSteps]]');
 const PullSteps = Symbol('[[PullSteps]]');
@@ -266,8 +267,7 @@ declare class ReadableStreamAsyncIteratorImpl<R> implements ReadableStreamAsyncI
   return(value?: any): Promise<IteratorResult<any>>;
 }
 
-const AsyncIteratorPrototype: AsyncIterator<any> = Object.getPrototypeOf(Object.getPrototypeOf(async function* (): AsyncIterableIterator<any> {}).prototype);
-const ReadableStreamAsyncIteratorPrototype: ReadableStreamAsyncIteratorImpl<any> = Object.setPrototypeOf({
+const ReadableStreamAsyncIteratorPrototype: ReadableStreamAsyncIteratorImpl<any> = {
   next(): Promise<IteratorResult<any>> {
     if (IsReadableStreamAsyncIterator(this) === false) {
       return Promise.reject(streamAsyncIteratorBrandCheckException('next'));
@@ -308,7 +308,10 @@ const ReadableStreamAsyncIteratorPrototype: ReadableStreamAsyncIteratorImpl<any>
     ReadableStreamReaderGenericRelease(reader);
     return Promise.resolve(ReadableStreamCreateReadResult(value, true, true));
   }
-}, AsyncIteratorPrototype);
+} as any;
+if (AsyncIteratorPrototype !== undefined) {
+  Object.setPrototypeOf(ReadableStreamAsyncIteratorPrototype, AsyncIteratorPrototype);
+}
 Object.defineProperty(ReadableStreamAsyncIteratorPrototype, 'next', { enumerable: false });
 Object.defineProperty(ReadableStreamAsyncIteratorPrototype, 'return', { enumerable: false });
 

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -234,7 +234,90 @@ class ReadableStream<R = any> {
     const branches = ReadableStreamTee(this, false);
     return createArrayFromList(branches);
   }
+
+  getIterator({ preventCancel = false }: { preventCancel?: boolean } = {}): ReadableStreamAsyncIterator<R> {
+    if (IsReadableStream(this) === false) {
+      throw streamBrandCheckException('getIterator');
+    }
+    const reader = AcquireReadableStreamDefaultReader<R>(this);
+    const iterator: ReadableStreamAsyncIteratorImpl<R> = Object.create(ReadableStreamAsyncIteratorPrototype);
+    iterator._asyncIteratorReader = reader;
+    iterator._preventCancel = Boolean(preventCancel);
+    return iterator;
+  }
+
+  [Symbol.asyncIterator]: (options?: { preventCancel?: boolean }) => ReadableStreamAsyncIterator<R>;
 }
+
+export interface ReadableStreamAsyncIterator<R> extends AsyncIterator<R> {
+  next(): Promise<IteratorResult<R>>;
+
+  return(value?: any): Promise<IteratorResult<any>>;
+}
+
+declare class ReadableStreamAsyncIteratorImpl<R> implements ReadableStreamAsyncIterator<R> {
+  /** @internal */
+  _asyncIteratorReader: ReadableStreamDefaultReader<R>;
+  /** @internal */
+  _preventCancel: boolean;
+
+  next(): Promise<IteratorResult<R>>;
+
+  return(value?: any): Promise<IteratorResult<any>>;
+}
+
+const AsyncIteratorPrototype: AsyncIterator<any> = Object.getPrototypeOf(Object.getPrototypeOf(async function* (): AsyncIterableIterator<any> {}).prototype);
+const ReadableStreamAsyncIteratorPrototype: ReadableStreamAsyncIteratorImpl<any> = Object.setPrototypeOf({
+  next(): Promise<IteratorResult<any>> {
+    if (IsReadableStreamAsyncIterator(this) === false) {
+      return Promise.reject(streamAsyncIteratorBrandCheckException('next'));
+    }
+    const reader = this._asyncIteratorReader;
+    if (reader._ownerReadableStream === undefined) {
+      return Promise.reject(readerLockException('iterate'));
+    }
+    return ReadableStreamDefaultReaderRead(reader).then(result => {
+      assert(typeIsObject(result));
+      const value = result.value;
+      const done = result.done;
+      assert(typeof done === 'boolean');
+      if (done) {
+        ReadableStreamReaderGenericRelease(reader);
+      }
+      return ReadableStreamCreateReadResult(value, done, true);
+    });
+  },
+
+  return(value: any): Promise<IteratorResult<any>> {
+    if (IsReadableStreamAsyncIterator(this) === false) {
+      return Promise.reject(streamAsyncIteratorBrandCheckException('next'));
+    }
+    const reader = this._asyncIteratorReader;
+    if (reader._ownerReadableStream === undefined) {
+      return Promise.reject(readerLockException('finish iterating'));
+    }
+    if (reader._readRequests.length > 0) {
+      return Promise.reject(new TypeError(
+        'Tried to release a reader lock when that reader has pending read() calls un-settled'));
+    }
+    if (this._preventCancel === false) {
+      const result = ReadableStreamReaderGenericCancel(reader, value);
+      ReadableStreamReaderGenericRelease(reader);
+      return result.then(() => ReadableStreamCreateReadResult(value, true, true));
+    }
+    ReadableStreamReaderGenericRelease(reader);
+    return Promise.resolve(ReadableStreamCreateReadResult(value, true, true));
+  }
+}, AsyncIteratorPrototype);
+Object.defineProperty(ReadableStreamAsyncIteratorPrototype, 'next', { enumerable: false });
+Object.defineProperty(ReadableStreamAsyncIteratorPrototype, 'return', { enumerable: false });
+
+Object.defineProperty(ReadableStream.prototype, Symbol.asyncIterator, {
+  value: ReadableStream.prototype.getIterator,
+  enumerable: false,
+  writable: true,
+  configurable: true
+});
 
 export {
   CreateReadableByteStream,
@@ -331,6 +414,18 @@ function IsReadableStreamLocked(stream: ReadableStream): boolean {
   assert(IsReadableStream(stream) === true);
 
   if (stream._reader === undefined) {
+    return false;
+  }
+
+  return true;
+}
+
+function IsReadableStreamAsyncIterator<R>(x: any): x is ReadableStreamAsyncIterator<R> {
+  if (!typeIsObject(x)) {
+    return false;
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(x, '_asyncIteratorReader')) {
     return false;
   }
 
@@ -2337,6 +2432,10 @@ function isAbortSignal(value: any): value is AbortSignal {
 
 function streamBrandCheckException(name: string): TypeError {
   return new TypeError(`ReadableStream.prototype.${name} can only be used on a ReadableStream`);
+}
+
+function streamAsyncIteratorBrandCheckException(name: string): TypeError {
+  return new TypeError(`ReadableStreamAsyncIterator.${name} can only be used on a ReadableSteamAsyncIterator`);
 }
 
 // Helper functions for the readers.

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -30,7 +30,7 @@ import {
   WritableStreamDefaultWriterWrite
 } from './writable-stream';
 import NumberIsInteger from '../stub/number-isinteger';
-import { AsyncIteratorPrototype } from '@target/stub/async-iterator-prototype';
+import { AsyncIteratorPrototype } from '@@target/stub/async-iterator-prototype';
 
 const CancelSteps = Symbol('[[CancelSteps]]');
 const PullSteps = Symbol('[[PullSteps]]');

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,12 +1,3 @@
-import assert from '../stub/assert';
+import { noop } from '../utils';
 
-export function rethrowAssertionErrorRejection(e: any) {
-  // Used throughout the reference implementation, as `.catch(rethrowAssertionErrorRejection)`, to ensure any errors
-  // get shown. There are places in the spec where we do promise transformations and purposefully ignore or don't
-  // expect any errors, but assertion errors are always problematic.
-  if (e && e instanceof assert.AssertionError) {
-    setTimeout(() => {
-      throw e;
-    }, 0);
-  }
-}
+export const rethrowAssertionErrorRejection: (e: any) => void = noop;

--- a/src/ponyfill.ts
+++ b/src/ponyfill.ts
@@ -2,6 +2,7 @@ import {
   PipeOptions,
   ReadableByteStreamControllerType,
   ReadableStream,
+  ReadableStreamAsyncIterator,
   ReadableStreamBYOBReaderType,
   ReadableStreamBYOBRequestType,
   ReadableStreamDefaultControllerType,
@@ -32,6 +33,7 @@ export {
   ReadableStreamBYOBRequestType as ReadableStreamBYOBRequest,
   ReadableStreamDefaultReaderType as ReadableStreamDefaultReader,
   ReadableStreamBYOBReaderType as ReadableStreamBYOBReader,
+  ReadableStreamAsyncIterator,
 
   WritableStream,
   UnderlyingSink,

--- a/src/stub/assert.ts
+++ b/src/stub/assert.ts
@@ -1,7 +1,4 @@
 import { noop } from '../utils';
 
-export default function assert(test: boolean): void { // eslint-disable-line @typescript-eslint/no-unused-vars
-  return; // do nothing
-}
-
-assert.AssertionError = noop;
+const assert: (test: boolean) => void = noop;
+export default assert;

--- a/src/stub/better-assert.ts
+++ b/src/stub/better-assert.ts
@@ -1,4 +1,1 @@
-import { noop } from '../utils';
-
-const betterAssert: (test: boolean) => void = noop;
-export default betterAssert;
+export { default } from './assert';

--- a/src/stub/debug.ts
+++ b/src/stub/debug.ts
@@ -1,4 +1,4 @@
 import { noop } from '../utils';
 
-const debug: (name: string) => (...message: any[]) => void = noop as any;
+const debug: (name: string) => (...message: any[]) => void = () => noop;
 export default debug;

--- a/src/target/es2018/stub/async-iterator-prototype.ts
+++ b/src/target/es2018/stub/async-iterator-prototype.ts
@@ -1,2 +1,2 @@
-export const AsyncIteratorPrototype: AsyncIterator<any> | undefined =
+export const AsyncIteratorPrototype: AsyncIterable<any> | undefined =
   Object.getPrototypeOf(Object.getPrototypeOf(async function* (): AsyncIterableIterator<any> {}).prototype);

--- a/src/target/es2018/stub/async-iterator-prototype.ts
+++ b/src/target/es2018/stub/async-iterator-prototype.ts
@@ -1,0 +1,2 @@
+export const AsyncIteratorPrototype: AsyncIterator<any> | undefined =
+  Object.getPrototypeOf(Object.getPrototypeOf(async function* (): AsyncIterableIterator<any> {}).prototype);

--- a/src/target/es5/stub/async-iterator-prototype.ts
+++ b/src/target/es5/stub/async-iterator-prototype.ts
@@ -1,1 +1,14 @@
-export const AsyncIteratorPrototype: AsyncIterator<any> | undefined = undefined;
+export let AsyncIteratorPrototype: AsyncIterable<any> | undefined = undefined;
+
+if (typeof Symbol.asyncIterator === 'symbol') {
+  // We're running inside a ES2018+ environment, but we're compiling to an older syntax.
+  // We cannot access %AsyncIteratorPrototype% without non-ES2018 syntax, but we can re-create it.
+  AsyncIteratorPrototype = {
+    // 25.1.3.1 %AsyncIteratorPrototype% [ @@asyncIterator ] ( )
+    // https://tc39.github.io/ecma262/#sec-asynciteratorprototype-asynciterator
+    [Symbol.asyncIterator]() {
+      return this as any;
+    }
+  };
+  Object.defineProperty(AsyncIteratorPrototype, Symbol.asyncIterator, { enumerable: false });
+}

--- a/src/target/es5/stub/async-iterator-prototype.ts
+++ b/src/target/es5/stub/async-iterator-prototype.ts
@@ -1,0 +1,1 @@
+export const AsyncIteratorPrototype: AsyncIterator<any> | undefined = undefined;

--- a/src/tsconfig-es2018.json
+++ b/src/tsconfig-es2018.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "es2018"
+  }
+}

--- a/src/tsconfig-es2018.json
+++ b/src/tsconfig-es2018.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2018",
+    "target": "esnext",
     "lib": [
       "dom",
       "es2018",

--- a/src/tsconfig-es2018.json
+++ b/src/tsconfig-es2018.json
@@ -8,7 +8,7 @@
       "esnext.asynciterable"
     ],
     "paths": {
-      "@target/*": [
+      "@@target/*": [
         "./target/es2018/*",
         "./target/es6/*",
         "./target/es5/*"

--- a/src/tsconfig-es2018.json
+++ b/src/tsconfig-es2018.json
@@ -1,6 +1,18 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2018"
+    "target": "es2018",
+    "lib": [
+      "dom",
+      "es2018",
+      "esnext.asynciterable"
+    ],
+    "paths": {
+      "@target/*": [
+        "./target/es2018/*",
+        "./target/es6/*",
+        "./target/es5/*"
+      ]
+    }
   }
 }

--- a/src/tsconfig-es6.json
+++ b/src/tsconfig-es6.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "es2015"
+  }
+}

--- a/src/tsconfig-es6.json
+++ b/src/tsconfig-es6.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "es2015",
     "paths": {
-      "@target/*": [
+      "@@target/*": [
         "./target/es6/*",
         "./target/es5/*"
       ]

--- a/src/tsconfig-es6.json
+++ b/src/tsconfig-es6.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2015"
+    "target": "es2015",
+    "paths": {
+      "@target/*": [
+        "./target/es6/*",
+        "./target/es5/*"
+      ]
+    }
   }
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "esnext",
     "module": "es2015",
+    "lib": [
+      "dom",
+      "es2018",
+      "esnext.asynciterable"
+    ],
     "strict": true,
     "stripInternal": true
   }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,13 +1,19 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es5",
     "module": "es2015",
     "lib": [
       "dom",
-      "es2018",
+      "es2015",
       "esnext.asynciterable"
     ],
     "strict": true,
-    "stripInternal": true
+    "stripInternal": true,
+    "baseUrl": ".",
+    "paths": {
+      "@target/*": [
+        "./target/es5/*"
+      ]
+    }
   }
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -11,7 +11,7 @@
     "stripInternal": true,
     "baseUrl": ".",
     "paths": {
-      "@target/*": [
+      "@@target/*": [
         "./target/es5/*"
       ]
     }

--- a/test/run-web-platform-tests.js
+++ b/test/run-web-platform-tests.js
@@ -28,8 +28,8 @@ main().catch(e => {
 });
 
 async function main() {
-  const entryPath = path.resolve(__dirname, 'dist/polyfill.es2018.min.js');
-  const testsPath = path.resolve(__dirname, 'test/web-platform-tests/streams');
+  const entryPath = path.resolve(__dirname, '../dist/polyfill.es2018.min.js');
+  const testsPath = path.resolve(__dirname, './web-platform-tests/streams');
 
   const includeGlobs = process.argv.length >= 3 ? process.argv.slice(2) : ['**/*.html'];
   const excludeGlobs = [

--- a/test/types/readable-stream.ts
+++ b/test/types/readable-stream.ts
@@ -96,6 +96,18 @@ const pipeThroughStream: ReadableStream<Uint8Array> = readableStream
     signal: undefined
   });
 
+const getIteratorResult: polyfill.ReadableStreamAsyncIterator<string> = readableStream.getIterator({ preventCancel: true });
+
+const asyncIterator: polyfill.ReadableStreamAsyncIterator<string> = readableStream[Symbol.asyncIterator]();
+const asyncIteratorNextResult: Promise<IteratorResult<string>> = asyncIterator.next();
+const asyncIteratorReturnResult: Promise<IteratorResult<any>> = asyncIterator.return('returned');
+
+(async () => {
+  for await (const chunk of readableStream) {
+    const chunkAsString: string = chunk;
+  }
+})();
+
 // Compatibility with stream types from DOM
 const domUnderlyingSource: UnderlyingSource<string> = underlyingSource;
 const domUnderlyingByteSource: UnderlyingByteSource = underlyingByteSource;

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "esnext",
     "module": "es2015",
     "moduleResolution": "node",
     "strict": true,
     "noEmit": true,
     "lib": [
       "dom",
-      "es5",
-      "es2015.promise"
+      "es2018",
+      "esnext.asynciterable"
     ]
   },
   "include": [

--- a/test/wpt-util/filtering-reporter.js
+++ b/test/wpt-util/filtering-reporter.js
@@ -1,0 +1,48 @@
+class FilteringReporter {
+  constructor(reporter, ignoredFailures = {}) {
+    this._reporter = reporter;
+    this._ignoredFailures = ignoredFailures;
+
+    this._currentSuite = '';
+    this._passed = 0;
+    this._failed = 0;
+    this._ignored = 0;
+  }
+
+  startSuite(name) {
+    this._currentSuite = name;
+    this._reporter.startSuite(name);
+  }
+
+  pass(message) {
+    this._passed++;
+    this._reporter.pass(message);
+  }
+
+  fail(message) {
+    const ignoredFailures = this._ignoredFailures[this._currentSuite];
+    if (ignoredFailures && ignoredFailures.includes(message.trim())) {
+      this._ignored++;
+      this._reporter.fail(`${message.trim()} (ignored)\n`);
+    } else {
+      this._failed++;
+      this._reporter.fail(message);
+    }
+  }
+
+  reportStack(stack) {
+    this._reporter.reportStack(stack);
+  }
+
+  getResults() {
+    return {
+      passed: this._passed,
+      failed: this._failed,
+      ignored: this._ignored
+    };
+  }
+}
+
+module.exports = {
+  FilteringReporter
+};


### PR DESCRIPTION
This implements `ReadableStream.prototype[Symbol.asyncIterator]()` and `ReadableStream.prototype.getIterator()`, introduced in [version `bf2cac8` (6 Feb 2019)](https://streams.spec.whatwg.org/commit-snapshots/bf2cac8a52664df3e6da7a48755890e87b00953a/) of the streams specification.

I've added ES2018 polyfill/ponyfill variants which use ES2018 async generator syntax. This is needed to make [`ReadableStreamAsyncIteratorPrototype`](https://streams.spec.whatwg.org/commit-snapshots/bf2cac8a52664df3e6da7a48755890e87b00953a/#rs-asynciterator-prototype) extend the native `%AsyncIteratorPrototype%`, which is needed to pass all of the new web platform tests.

However, the ES5 and ES6 variants will still define a working async iterator method as long as `Symbol.asyncIterator` exists. If you use these variants inside a native ES2018+ environment or with a polyfill for `Symbol.asyncIterator` (e.g. Babel), you can still use a (native or transpiled) `for-await-of` loop on a `ReadableStream` with no problem. In fact, other than that one test for the async iterator's prototype, the ES6 variant still passes all tests on Node 10. 😄 

Internally, I've restructured the variant builds (again). We now have separate TypeScript configurations for the separate targets (`es5`, `es6` and `es2018`). Each define a [path mapping](http://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping) for `@@target/*`, so we can define different versions of the same module depending on the compilation target. This is used to retrieve the native `AsyncIteratorPrototype` for the ES2018 build, or use a polyfill for the ES5 and ES6 builds.

I've added more exclusions to the web platform test runner:
* We skip the [_"Async iterator instances should have the correct list of properties"_](https://github.com/web-platform-tests/wpt/blob/de6f8fcf9b87e80811e9267a886cf891f6f864e0/streams/readable-streams/async-iterator.any.js#L11) test for the ES6 variant, since we cannot access the native `%AsyncIteratorPrototype%` without ES2018 syntax.
* We skip all async iterator tests when running inside a non-ES2018 environment (e.g. Node 8 or lower). This is unavoidable, since the tests use ES2018 syntax which fails to parse in these environments. Similarly, we skip the [_"ReadableStream instances should have the correct list of properties"_](https://github.com/web-platform-tests/wpt/blob/de6f8fcf9b87e80811e9267a886cf891f6f864e0/streams/readable-streams/general.any.js#L40) test since `Symbol.asyncIterator` does not exist in these environments.