### PR TITLE
Update to spec version of 21 February 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * 🚀 Add `@@asyncIterator` to `ReadableStream` ([#11](https://github.com/MattiasBuelens/web-streams-polyfill/pull/11))
 * 🚀 Add `polyfill/es2018` and `ponyfill/es2018` variants ([#11](https://github.com/MattiasBuelens/web-streams-polyfill/pull/11))
 * 🐛 Fix using unsupported `Object.assign` on Internet Explorer
-* 👓 Align with [spec version `bf2cac8`](https://github.com/whatwg/streams/tree/bf2cac8a52664df3e6da7a48755890e87b00953a/) ([#11](https://github.com/MattiasBuelens/web-streams-polyfill/pull/11))
+* 👓 Align with [spec version `2c8f35e`](https://github.com/whatwg/streams/tree/2c8f35ed23451ffc9b32ec37b56def4a5349abb1/) ([#11](https://github.com/MattiasBuelens/web-streams-polyfill/pull/11), [#12](https://github.com/MattiasBuelens/web-streams-polyfill/pull/12))
 
 ## v0.3.1 (2019-02-25)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `polyfill/es2018` and `ponyfill/es2018` variants work in any ES2018-compatib
 
 ### Compliance
 
-The polyfill implements [version `bf2cac8` (6 Feb 2019)](https://streams.spec.whatwg.org/commit-snapshots/bf2cac8a52664df3e6da7a48755890e87b00953a/) of the streams specification.
+The polyfill implements [version `2c8f35e` (21 Feb 2019)](https://streams.spec.whatwg.org/commit-snapshots/2c8f35ed23451ffc9b32ec37b56def4a5349abb1/) of the streams specification.
 
 The type definitions are compatible with the built-in stream types of TypeScript 3.3.
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,4 +1,4 @@
-import assert from '../stub/better-assert';
+import assert from '../stub/assert';
 import NumberIsNaN from '../stub/number-isnan';
 import { FunctionPropertyNames, InferFirst, InferFunction, InferRest, Promisify } from '../util/type-utils';
 

--- a/src/lib/queue-with-sizes.ts
+++ b/src/lib/queue-with-sizes.ts
@@ -1,4 +1,4 @@
-import assert from '../stub/better-assert';
+import assert from '../stub/assert';
 import { IsFiniteNonNegativeNumber } from './helpers';
 
 export interface QueueContainer<T> {

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -2344,6 +2344,7 @@ function SetUpReadableByteStreamController(stream: ReadableByteStream,
   controller._pullAgain = false;
   controller._pulling = false;
 
+  controller._byobRequest = undefined;
   ReadableByteStreamControllerClearPendingPullIntos(controller);
 
   // Need to set the slots so that the assert doesn't fire. In the spec the slots already exist implicitly.

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -2333,7 +2333,6 @@ function SetUpReadableByteStreamController(stream: ReadableByteStream,
   controller._pulling = false;
 
   controller._byobRequest = undefined;
-  ReadableByteStreamControllerClearPendingPullIntos(controller);
 
   // Need to set the slots so that the assert doesn't fire. In the spec the slots already exist implicitly.
   controller._queue = controller._queueTotalSize = undefined!;

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -572,10 +572,7 @@ function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
       }
     }
 
-    pipeLoop().catch(err => {
-      currentWrite = Promise.resolve();
-      rethrowAssertionErrorRejection(err);
-    });
+    pipeLoop().catch(rethrowAssertionErrorRejection);
 
     function waitForWritesToFinish(): Promise<void> {
       // Another write may have started while we were waiting on this currentWrite, so we have to be sure to wait
@@ -815,7 +812,7 @@ function ReadableStreamClose<R>(stream: ReadableStream<R>): void {
   const reader = stream._reader;
 
   if (reader === undefined) {
-    return undefined;
+    return;
   }
 
   if (IsReadableStreamDefaultReader<R>(reader)) {
@@ -826,8 +823,6 @@ function ReadableStreamClose<R>(stream: ReadableStream<R>): void {
   }
 
   defaultReaderClosedPromiseResolve(reader);
-
-  return undefined;
 }
 
 function ReadableStreamCreateReadResult<T>(value: T | undefined, done: boolean, forAuthorCode: boolean): ReadResult<T> {
@@ -852,7 +847,7 @@ function ReadableStreamError<R>(stream: ReadableStream<R>, e: any): void {
   const reader = stream._reader;
 
   if (reader === undefined) {
-    return undefined;
+    return;
   }
 
   if (IsReadableStreamDefaultReader<R>(reader)) {
@@ -1339,15 +1334,15 @@ function IsReadableStreamDefaultController<R>(x: any): x is ReadableStreamDefaul
   return true;
 }
 
-function ReadableStreamDefaultControllerCallPullIfNeeded(controller: ReadableStreamDefaultController<any>) {
+function ReadableStreamDefaultControllerCallPullIfNeeded(controller: ReadableStreamDefaultController<any>): void {
   const shouldPull = ReadableStreamDefaultControllerShouldCallPull(controller);
   if (shouldPull === false) {
-    return undefined;
+    return;
   }
 
   if (controller._pulling === true) {
     controller._pullAgain = true;
-    return undefined;
+    return;
   }
 
   assert(controller._pullAgain === false);
@@ -1361,16 +1356,13 @@ function ReadableStreamDefaultControllerCallPullIfNeeded(controller: ReadableStr
 
       if (controller._pullAgain === true) {
         controller._pullAgain = false;
-        return ReadableStreamDefaultControllerCallPullIfNeeded(controller);
+        ReadableStreamDefaultControllerCallPullIfNeeded(controller);
       }
-      return undefined;
     },
     e => {
       ReadableStreamDefaultControllerError(controller, e);
     }
   ).catch(rethrowAssertionErrorRejection);
-
-  return undefined;
 }
 
 function ReadableStreamDefaultControllerShouldCallPull(controller: ReadableStreamDefaultController<any>): boolean {
@@ -1418,7 +1410,7 @@ function ReadableStreamDefaultControllerClose(controller: ReadableStreamDefaultC
   }
 }
 
-function ReadableStreamDefaultControllerEnqueue<R>(controller: ReadableStreamDefaultController<R>, chunk: R) {
+function ReadableStreamDefaultControllerEnqueue<R>(controller: ReadableStreamDefaultController<R>, chunk: R): void {
   const stream = controller._controlledReadableStream;
 
   assert(ReadableStreamDefaultControllerCanCloseOrEnqueue(controller) === true);
@@ -1443,8 +1435,6 @@ function ReadableStreamDefaultControllerEnqueue<R>(controller: ReadableStreamDef
   }
 
   ReadableStreamDefaultControllerCallPullIfNeeded(controller);
-
-  return undefined;
 }
 
 function ReadableStreamDefaultControllerError(controller: ReadableStreamDefaultController<any>, e: any) {
@@ -1863,12 +1853,12 @@ function IsReadableStreamBYOBRequest(x: any): x is ReadableStreamBYOBRequest {
 function ReadableByteStreamControllerCallPullIfNeeded(controller: ReadableByteStreamController): void {
   const shouldPull = ReadableByteStreamControllerShouldCallPull(controller);
   if (shouldPull === false) {
-    return undefined;
+    return;
   }
 
   if (controller._pulling === true) {
     controller._pullAgain = true;
-    return undefined;
+    return;
   }
 
   assert(controller._pullAgain === false);
@@ -1890,8 +1880,6 @@ function ReadableByteStreamControllerCallPullIfNeeded(controller: ReadableByteSt
       ReadableByteStreamControllerError(controller, e);
     }
   ).catch(rethrowAssertionErrorRejection);
-
-  return undefined;
 }
 
 function ReadableByteStreamControllerClearPendingPullIntos(controller: ReadableByteStreamController) {

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
 /* global AbortSignal:false */
 
-import assert from '../stub/better-assert';
+import assert from '../stub/assert';
 import {
   ArrayBufferCopy,
   CreateAlgorithmFromUnderlyingMethod,

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -279,12 +279,12 @@ const ReadableStreamAsyncIteratorPrototype: ReadableStreamAsyncIteratorImpl<any>
     }
     return ReadableStreamDefaultReaderRead(reader).then(result => {
       assert(typeIsObject(result));
-      const value = result.value;
       const done = result.done;
       assert(typeof done === 'boolean');
       if (done) {
         ReadableStreamReaderGenericRelease(reader);
       }
+      const value = result.value;
       return ReadableStreamCreateReadResult(value, done, true);
     });
   },

--- a/src/lib/transform-stream.ts
+++ b/src/lib/transform-stream.ts
@@ -1,4 +1,4 @@
-import assert from '../stub/better-assert';
+import assert from '../stub/assert';
 import debug from '../stub/debug';
 import {
   CreateAlgorithmFromUnderlyingMethod,

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -986,9 +986,7 @@ function WritableStreamDefaultControllerAdvanceQueueIfNeeded<W>(controller: Writ
   }
 
   const state = stream._state;
-  if (state === 'closed' || state === 'errored') {
-    return;
-  }
+  assert(state !== 'closed' && state !== 'errored');
   if (state === 'erroring') {
     WritableStreamFinishErroring(stream);
     return;

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -1,4 +1,4 @@
-import assert from '../stub/better-assert';
+import assert from '../stub/assert';
 import debug from '../stub/debug';
 import {
   CreateAlgorithmFromUnderlyingMethod,

--- a/src/stub/better-assert.ts
+++ b/src/stub/better-assert.ts
@@ -1,1 +1,0 @@
-export { default } from './assert';


### PR DESCRIPTION
This aligns the implementation with [spec version `2c8f35e` of 21 February](https://streams.spec.whatwg.org/commit-snapshots/2c8f35ed23451ffc9b32ec37b56def4a5349abb1/) (which is the latest version at the time of writing).

Comparison: https://github.com/whatwg/streams/compare/bf2cac8a52664df3e6da7a48755890e87b00953a...2c8f35ed23451ffc9b32ec37b56def4a5349abb1