### PR TITLE
Rename package to web-streams-polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,37 +8,3 @@
 > - 📝 Documentation
 > - 🏠 Internal
 > - 💅 Polish
-
-## v0.3.2 (2019-03-10)
-
-* 🚀 Add `@@asyncIterator` to `ReadableStream` ([#11](https://github.com/MattiasBuelens/web-streams-polyfill/pull/11))
-* 🚀 Add `polyfill/es2018` and `ponyfill/es2018` variants ([#11](https://github.com/MattiasBuelens/web-streams-polyfill/pull/11))
-* 🐛 Fix using unsupported `Object.assign` on Internet Explorer
-* 👓 Align with [spec version `2c8f35e`](https://github.com/whatwg/streams/tree/2c8f35ed23451ffc9b32ec37b56def4a5349abb1/) ([#11](https://github.com/MattiasBuelens/web-streams-polyfill/pull/11), [#12](https://github.com/MattiasBuelens/web-streams-polyfill/pull/12))
-
-## v0.3.1 (2019-02-25)
-
-* 🐛 Fix ES5 build target ([#9](https://github.com/MattiasBuelens/web-streams-polyfill/pull/9))
-
-## v0.3.0 (2019-02-21)
-
-* 💥 **Breaking change:** The type of `TransformStream<R, W>` is changed to `TransformStream<I, O>` and the meaning of the two type parameters is flipped, to align the polyfill with the built-in type definitions of TypeScript 3.2.
-* 🚀 Add `polyfill/es6` variant
-* 🐛 Fix memory leak when using streams in a microtask loop in Node.js ([#8](https://github.com/MattiasBuelens/web-streams-polyfill/pull/8))
-* 🏠 Switch to TypeScript ([#7](https://github.com/MattiasBuelens/web-streams-polyfill/pull/7))
-* 💅 Improve type definitions ([#7](https://github.com/MattiasBuelens/web-streams-polyfill/pull/7))
-
-## v0.2.1 (2018-12-31)
-
-* 🐛 Do not copy `ArrayBuffer` when transferring chunk to readable byte stream ([#3](https://github.com/MattiasBuelens/web-streams-polyfill/issues/3), [#4](https://github.com/MattiasBuelens/web-streams-polyfill/pull/4))
-* 👓 Align with [spec version `1116de0`](https://github.com/whatwg/streams/tree/1116de06e94bf4406c60b1e766111dfd8bc7bfcd/)
-
-## v0.2.0 (2018-11-15)
-
-* 🐛 Avoid long promise chains in `ReadableStream.pipeTo()` ([whatwg/streams#968](https://github.com/whatwg/streams/pull/968))
-* 👓 Align with [spec version `46c3b89`](https://github.com/whatwg/streams/tree/46c3b89dd3aff28b2fc381dd1d397c12b4fb8a16/)
-
-## v0.1.0 (2018-08-15)
-
-* 🚀 Initial release
-* 👓 Align with [spec version `78cfd1e`](https://github.com/whatwg/streams/tree/78cfd1e22b717ce7e6d3aae4e36de0ef9101356e/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,20 @@
 > - 📝 Documentation
 > - 🏠 Internal
 > - 💅 Polish
+
+## Unreleased
+
+* 💥 Ownership change: [@mattiasbuelens/web-streams-polyfill](https://www.npmjs.com/package/@mattiasbuelens/web-streams-polyfill/v/0.3.2) has been republished as [web-streams-polyfill](https://www.npmjs.com/package/web-streams-polyfill).
+  For the full list of changes between web-streams-polyfill v1.3.2 and this version, [visit the fork's changelog](https://github.com/MattiasBuelens/web-streams-polyfill/blob/v0.3.2/CHANGELOG.md).
+
+* 💥 CommonJS entry points have been moved to `dist/`:
+  * `index.js` ➡ `dist/polyfill.js`
+  * `index.es6.js` ➡ `dist/polyfill.es6.js`
+
+  However, we recommend migrating to a [variant sub-package](https://github.com/MattiasBuelens/web-streams-polyfill#usage) instead:
+  * `require('web-streams-polyfill/index.js')` ➡ `require('web-streams-polyfill')`
+  * `require('web-streams-polyfill/index.es6.js')` ➡ `require('web-streams-polyfill/es6')`
+
+* 👓 Align with [spec version `2c8f35e`](https://github.com/whatwg/streams/tree/2c8f35ed23451ffc9b32ec37b56def4a5349abb1/)
+
+* 🏠 Code moved from [creatorrr/web-streams-polyfill](https://github.com/creatorrr/web-streams-polyfill) to [MattiasBuelens/web-streams-polyfill](https://github.com/MattiasBuelens/web-streams-polyfill)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Web Streams, based on the WHATWG spec reference implementation.  
 
 [![build status](https://api.travis-ci.com/MattiasBuelens/web-streams-polyfill.svg?branch=master)](https://travis-ci.com/MattiasBuelens/web-streams-polyfill)
-[![npm version](https://img.shields.io/npm/v/@mattiasbuelens/web-streams-polyfill.svg)](https://www.npmjs.com/package/@mattiasbuelens/web-streams-polyfill)
-[![license](https://img.shields.io/npm/l/@mattiasbuelens/web-streams-polyfill.svg)](https://github.com/MattiasBuelens/web-streams-polyfill/blob/master/LICENSE)
+[![npm version](https://img.shields.io/npm/v/web-streams-polyfill.svg)](https://www.npmjs.com/package/web-streams-polyfill)
+[![license](https://img.shields.io/npm/l/web-streams-polyfill.svg)](https://github.com/MattiasBuelens/web-streams-polyfill/blob/master/LICENSE)
 [![Join the chat at https://gitter.im/web-streams-polyfill/Lobby](https://badges.gitter.im/web-streams-polyfill/Lobby.svg)](https://gitter.im/web-streams-polyfill/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Links
@@ -15,18 +15,18 @@ Web Streams, based on the WHATWG spec reference implementation.
 ## Usage
 
 This library comes in multiple variants:
-* `@mattiasbuelens/web-streams-polyfill`: a polyfill that replaces the native stream implementations.
+* `web-streams-polyfill`: a polyfill that replaces the native stream implementations.
   Recommended for use in web apps supporting older browsers through a `<script>` tag.
-* `@mattiasbuelens/web-streams-polyfill/es6`: a polyfill targeting ES2015+ environments.
+* `web-streams-polyfill/es6`: a polyfill targeting ES2015+ environments.
   Recommended for use in web apps supporting modern browsers through a `<script>` tag.
-* `@mattiasbuelens/web-streams-polyfill/es2018`: a polyfill targeting ES2018+ environments.
+* `web-streams-polyfill/es2018`: a polyfill targeting ES2018+ environments.
   Required for [`ReadableStream` async iterable support][rs-asynciterator].
-* `@mattiasbuelens/web-streams-polyfill/ponyfill`: a [ponyfill] that provides
+* `web-streams-polyfill/ponyfill`: a [ponyfill] that provides
   the stream implementations without replacing any globals.
   Recommended for use in legacy Node applications, or in web libraries supporting older browsers.
-* `@mattiasbuelens/web-streams-polyfill/ponyfill/es6`: a ponyfill targeting ES2015+ environments.
+* `web-streams-polyfill/ponyfill/es6`: a ponyfill targeting ES2015+ environments.
   Recommended for use in Node 6+ applications, or in web libraries supporting modern browsers.
-* `@mattiasbuelens/web-streams-polyfill/ponyfill/es2018`: a ponyfill targeting ES2018+ environments.
+* `web-streams-polyfill/ponyfill/es2018`: a ponyfill targeting ES2018+ environments.
   Recommended for use in Node 10+ applications.
 
 Each variant also includes TypeScript type definitions, compatible with the DOM type definitions for streams included in TypeScript.
@@ -34,7 +34,7 @@ Each variant also includes TypeScript type definitions, compatible with the DOM 
 Usage as a polyfill:
 ```html
 <!-- option 1: hosted by unpkg CDN -->
-<script src="https://unpkg.com/@mattiasbuelens/web-streams-polyfill/dist/polyfill.min.js"></script>
+<script src="https://unpkg.com/web-streams-polyfill/dist/polyfill.min.js"></script>
 <!-- option 2: self hosted -->
 <script src="/path/to/web-streams-polyfill/dist/polyfill.min.js"></script>
 <script>
@@ -43,12 +43,12 @@ var readable = new ReadableStream();
 ```
 Usage as a Node module:
 ```js
-var streams = require("@mattiasbuelens/web-streams-polyfill/ponyfill");
+var streams = require("web-streams-polyfill/ponyfill");
 var readable = new streams.ReadableStream();
 ```
 Usage as a ES2015 module:
 ```js
-import { ReadableStream } from "@mattiasbuelens/web-streams-polyfill/ponyfill";
+import { ReadableStream } from "web-streams-polyfill/ponyfill";
 const readable = new ReadableStream();
 ```
 

--- a/es2018/package.json
+++ b/es2018/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mattiasbuelens/web-streams-polyfill-es2018",
+  "name": "web-streams-polyfill-es2018",
   "main": "../dist/polyfill.es2018",
   "browser": "../dist/polyfill.es2018.min.js",
   "module": "../dist/polyfill.es2018.mjs",

--- a/es6/package.json
+++ b/es6/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mattiasbuelens/web-streams-polyfill-es6",
+  "name": "web-streams-polyfill-es6",
   "main": "../dist/polyfill.es6",
   "browser": "../dist/polyfill.es6.min.js",
   "module": "../dist/polyfill.es6.mjs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mattiasbuelens/web-streams-polyfill",
+  "name": "web-streams-polyfill",
   "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mattiasbuelens/web-streams-polyfill",
+  "name": "web-streams-polyfill",
   "version": "0.3.2",
   "description": "Web Streams, based on the WHATWG spec reference implementation",
   "main": "dist/polyfill",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "whatwg",
     "polyfill"
   ],
-  "author": "Diwank Singh <diwank.singh@gmail.com>",
+  "author": "Mattias Buelens <mattias@buelens.com>",
   "contributors": [
-    "Mattias Buelens <mattias@buelens.com>"
+    "Diwank Singh <diwank.singh@gmail.com>"
   ],
   "license": "MIT",
   "bugs": {

--- a/ponyfill/es2018/package.json
+++ b/ponyfill/es2018/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mattiasbuelens/web-streams-ponyfill-es2018",
+  "name": "web-streams-ponyfill-es2018",
   "main": "../../dist/ponyfill.es2018",
   "module": "../../dist/ponyfill.es2018.mjs",
   "types": "../../dist/types/polyfill.d.ts"

--- a/ponyfill/es6/package.json
+++ b/ponyfill/es6/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mattiasbuelens/web-streams-ponyfill-es6",
+  "name": "web-streams-ponyfill-es6",
   "main": "../../dist/ponyfill.es6",
   "module": "../../dist/ponyfill.es6.mjs",
   "types": "../../dist/types/polyfill.d.ts"

--- a/ponyfill/package.json
+++ b/ponyfill/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mattiasbuelens/web-streams-ponyfill",
+  "name": "web-streams-ponyfill",
   "main": "../dist/ponyfill",
   "module": "../dist/ponyfill.mjs",
   "types": "../dist/types/polyfill.d.ts"


### PR DESCRIPTION
This renames the package from `@mattiasbuelens/web-streams-polyfill` to `web-streams-polyfill`, and updates the changelog and documentation to reflect the change.

Part of #13