### PR TITLE
Fix performance issue with large queues

### DIFF
--- a/src/lib/queue-with-sizes.ts
+++ b/src/lib/queue-with-sizes.ts
@@ -1,8 +1,9 @@
 import assert from '../stub/assert';
 import { IsFiniteNonNegativeNumber } from './helpers';
+import { SimpleQueue } from './simple-queue';
 
 export interface QueueContainer<T> {
-  _queue: T[];
+  _queue: SimpleQueue<T>;
   _queueTotalSize: number;
 }
 
@@ -40,13 +41,13 @@ export function PeekQueueValue<T>(container: QueueContainer<QueuePair<T>>): T {
   assert('_queue' in container && '_queueTotalSize' in container);
   assert(container._queue.length > 0);
 
-  const pair = container._queue[0];
+  const pair = container._queue.peek();
   return pair.value;
 }
 
 export function ResetQueue<T>(container: QueueContainer<T>) {
   assert('_queue' in container && '_queueTotalSize' in container);
 
-  container._queue = [];
+  container._queue = new SimpleQueue<T>();
   container._queueTotalSize = 0;
 }

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -32,6 +32,7 @@ import {
 } from './writable-stream';
 import NumberIsInteger from '../stub/number-isinteger';
 import { AsyncIteratorPrototype } from '@@target/stub/async-iterator-prototype';
+import { SimpleQueue } from './simple-queue';
 
 const CancelSteps = Symbol('[[CancelSteps]]');
 const PullSteps = Symbol('[[PullSteps]]');
@@ -1220,7 +1221,7 @@ class ReadableStreamDefaultController<R> {
   /** @internal */
   _controlledReadableStream!: ReadableStream<R>;
   /** @internal */
-  _queue!: Array<QueuePair<R>>;
+  _queue!: SimpleQueue<QueuePair<R>>;
   /** @internal */
   _queueTotalSize!: number;
   /** @internal */
@@ -1647,7 +1648,7 @@ class ReadableByteStreamController {
   /** @internal */
   _controlledReadableByteStream!: ReadableByteStream;
   /** @internal */
-  _queue!: ByteQueueElement[];
+  _queue!: SimpleQueue<ByteQueueElement>;
   /** @internal */
   _queueTotalSize!: number;
   /** @internal */
@@ -1942,7 +1943,7 @@ function ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller:
   const queue = controller._queue;
 
   while (totalBytesToCopyRemaining > 0) {
-    const headOfQueue = queue[0];
+    const headOfQueue = queue.peek();
 
     const bytesToCopy = Math.min(totalBytesToCopyRemaining, headOfQueue.byteLength);
 

--- a/src/lib/simple-queue.ts
+++ b/src/lib/simple-queue.ts
@@ -1,0 +1,61 @@
+import assert from '../stub/assert';
+
+const CHUNK_SIZE = 16384;
+
+/**
+ * Simple queue structure.
+ *
+ * Avoids scalability issues with large arrays in Chrome
+ * by using an array of bounded arrays instead.
+ *
+ * @see https://github.com/MattiasBuelens/web-streams-polyfill/issues/15
+ */
+export class SimpleQueue<T> {
+  private readonly _chunks: T[][];
+  private _front: T[];
+  private _back: T[];
+  private _size: number = 0;
+
+  constructor() {
+    const chunk: T[] = [];
+    this._chunks = [chunk];
+    this._front = chunk;
+    this._back = chunk;
+    this._size = 0;
+  }
+
+  get length(): number {
+    return this._size;
+  }
+
+  push(element: T): void {
+    this._back.push(element);
+    ++this._size;
+
+    if (this._back.length === CHUNK_SIZE) {
+      this._back = [];
+      this._chunks.push(this._back);
+    }
+  }
+
+  shift(): T {
+    assert(this._size > 0); // must not be called on an empty queue
+
+    const element = this._front.shift()!;
+    --this._size;
+
+    if (this._front.length === 0 && this._front !== this._back) {
+      this._chunks.shift();
+      this._front = this._chunks[0];
+    }
+
+    return element;
+  }
+
+  peek(): T {
+    assert(this._size > 0); // must not be called on an empty queue
+
+    return this._front[0];
+  }
+
+}

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -10,6 +10,7 @@ import {
 import { rethrowAssertionErrorRejection } from './utils';
 import { DequeueValue, EnqueueValueWithSize, PeekQueueValue, QueuePair, ResetQueue } from './queue-with-sizes';
 import { QueuingStrategy, QueuingStrategySizeCallback } from './queuing-strategy';
+import { SimpleQueue } from './simple-queue';
 
 const AbortSteps = Symbol('[[AbortSteps]]');
 const ErrorSteps = Symbol('[[ErrorSteps]]');
@@ -775,7 +776,7 @@ class WritableStreamDefaultController<W = any> {
   /** @internal */
   _controlledWritableStream!: WritableStream<W>;
   /** @internal */
-  _queue!: Array<QueuePair<QueueRecord<W>>>;
+  _queue!: SimpleQueue<QueuePair<QueueRecord<W>>>;
   /** @internal */
   _queueTotalSize!: number;
   /** @internal */


### PR DESCRIPTION
Add a `SimpleQueue` that queues elements in bounded chunks, to avoid scalability issues with large arrays in Chrome.

Fixes #15