### PR TITLE
Optimize data properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ## Unreleased
 
+* 💅 Improve performance of `ReadableStreamDefaultReader.read()` ([#17](https://github.com/MattiasBuelens/web-streams-polyfill/pull/17))
+
 ## v2.0.1 (2019-03-16)
 
 * 🐛 Fix performance issue with large queues ([#15](https://github.com/MattiasBuelens/web-streams-polyfill/pull/15), [#16](https://github.com/MattiasBuelens/web-streams-polyfill/pull/16))

--- a/src/lib/byte-length-queuing-strategy.ts
+++ b/src/lib/byte-length-queuing-strategy.ts
@@ -1,11 +1,10 @@
-import { createDataProperty } from './helpers';
 import { QueuingStrategy } from './queuing-strategy';
 
 export default class ByteLengthQueuingStrategy implements QueuingStrategy<ArrayBufferView> {
   readonly highWaterMark!: number;
 
   constructor({ highWaterMark }: { highWaterMark: number }) {
-    createDataProperty(this, 'highWaterMark', highWaterMark);
+    this.highWaterMark = highWaterMark;
   }
 
   size(chunk: ArrayBufferView): number {

--- a/src/lib/count-queuing-strategy.ts
+++ b/src/lib/count-queuing-strategy.ts
@@ -1,11 +1,10 @@
-import { createDataProperty } from './helpers';
 import { QueuingStrategy } from './queuing-strategy';
 
 export default class CountQueuingStrategy implements QueuingStrategy<any> {
   readonly highWaterMark!: number;
 
   constructor({ highWaterMark }: { highWaterMark: number }) {
-    createDataProperty(this, 'highWaterMark', highWaterMark);
+    this.highWaterMark = highWaterMark;
   }
 
   size(): 1 {

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -829,8 +829,8 @@ function ReadableStreamCreateReadResult<T>(value: T | undefined, done: boolean, 
   }
   assert(typeof done === 'boolean');
   const obj: ReadResult<T> = Object.create(prototype);
-  Object.defineProperty(obj, 'value', { value, enumerable: true, writable: true, configurable: true });
-  Object.defineProperty(obj, 'done', { value: done, enumerable: true, writable: true, configurable: true });
+  obj.value = value!;
+  obj.done = done;
   return obj;
 }
 

--- a/test/benchmark/index.js
+++ b/test/benchmark/index.js
@@ -1,0 +1,55 @@
+const Benchmark = require('benchmark');
+const polyfill = require('../../dist/polyfill.es6.js');
+const stardazed = require('@stardazed/streams');
+const suite = new Benchmark.Suite();
+
+const implementations = [
+  ['web-streams-polyfill', polyfill],
+  ['@stardazed/streams', stardazed]
+];
+
+// https://github.com/MattiasBuelens/web-streams-polyfill/issues/15
+function testCount(impl, count, deferred) {
+  const rs = new impl.ReadableStream({
+    start(controller) {
+      for (let i = 0; i < count; ++i) {
+        controller.enqueue(i);
+      }
+      controller.close();
+    }
+  });
+  const reader = rs.getReader();
+  return readLoop(count, reader)
+    .then(() => deferred.resolve());
+}
+
+function readLoop(count, reader) {
+  return reader.read().then(result => {
+    if (result.done) {
+      return undefined;
+    }
+    return readLoop(count, reader);
+  });
+}
+
+for (const [name, impl] of implementations) {
+  for (let count = 3545; count <= 113440; count *= 2) {
+    suite.add(
+      `${name} testCount(${count})`,
+      deferred => testCount(impl, count, deferred),
+      { defer: true }
+    );
+  }
+}
+
+suite
+  .on('cycle', event => {
+    // eslint-disable-next-line no-console
+    const bench = event.target;
+    console.log(`${String(bench)} (period: ${(bench.times.period * 1000).toFixed(2)}ms)`);
+  })
+  .on('complete', () => {
+    // eslint-disable-next-line no-console
+    console.log('Done');
+  })
+  .run({ async: true });

--- a/test/benchmark/package-lock.json
+++ b/test/benchmark/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "web-streams-polyfill-benchmark",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@stardazed/streams": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@stardazed/streams/-/streams-3.0.0.tgz",
+      "integrity": "sha512-CCZmu6xD8SPhI/llli4KV4YyLqUlP75rymxSRJu/Cp67ECKrOj5OxWSxuJBEG7iebd5wiPbP3DeXjvs7DMtAYA==",
+      "dev": true
+    },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+      "dev": true
+    }
+  }
+}

--- a/test/benchmark/package.json
+++ b/test/benchmark/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "web-streams-polyfill-benchmark",
+  "version": "0.0.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "benchmark": "node --prof index.js"
+  },
+  "devDependencies": {
+    "@stardazed/streams": "^3.0.0",
+    "benchmark": "^2.1.4"
+  }
+}


### PR DESCRIPTION
In #16, [I noticed](https://github.com/MattiasBuelens/web-streams-polyfill/pull/16#issuecomment-473472465) that Stardazed Streams were more than 2x faster than this polyfill. This sparked my interest, so I set out to find where this polyfill was spending the extra time.

I set up a benchmark suite using [Benchmark.js](https://benchmarkjs.com/) to compare the performance of this polyfill and Stardazed's implementation on the [code snippet](https://codepen.io/anon/pen/gEpXXb) from #15. Then, I used [flamebearer](https://github.com/mapbox/flamebearer) to create the following flame graphs:

**web-streams-polyfill**
![flamegraph-polyfill](https://user-images.githubusercontent.com/649348/54479485-7f63a900-481d-11e9-9f7a-31e5ae849e2f.png)
**@stardazed/streams**
![flamegraph-stardazed](https://user-images.githubusercontent.com/649348/54479487-8094d600-481d-11e9-8eea-d6f892f1c8d9.png)

I'm not an expert, but it looks like the polyfill's `reader.read()` spends a lot of time in some sort of built-in Node function.

I went to compare the `ReadableStreamDefaultReaderRead` implementation of `web-streams-polyfill` and `@stardazed/streams`, and I only found one difference inside `ReadableStreamCreateReadResult`. [The polyfill](https://github.com/MattiasBuelens/web-streams-polyfill/blob/v2.0.1/src/lib/readable-stream.ts#L832) uses `Object.defineProperty` to set `value` and `done`:
```js
  Object.defineProperty(obj, 'value', { value, enumerable: true, writable: true, configurable: true });
  Object.defineProperty(obj, 'done', { value: done, enumerable: true, writable: true, configurable: true });
```
While [Stardazed](https://github.com/stardazed/sd-streams/blob/86c5c33c054782ce77d091e8ddcd5da018846006/packages/streams/src/readable-internals.ts#L227) sets those with a regular property assignment:
```js
  result.value = value;
  result.done = done;
```

Indeed, that fixes the performance issue! 🎉 
![flamegraph-polyfill-fixed](https://user-images.githubusercontent.com/649348/54479605-a5d61400-481e-11e9-8456-d0650fc0f336.png)

Benchmark results before:
```
> node --prof index.js

web-streams-polyfill testCount(3545) x 205 ops/sec ±1.20% (82 runs sampled) (period: 4.88ms)
web-streams-polyfill testCount(7090) x 102 ops/sec ±0.73% (76 runs sampled) (period: 9.82ms)
web-streams-polyfill testCount(14180) x 48.69 ops/sec ±2.41% (74 runs sampled) (period: 20.54ms)
web-streams-polyfill testCount(28360) x 22.74 ops/sec ±1.54% (56 runs sampled) (period: 43.97ms)
web-streams-polyfill testCount(56720) x 10.68 ops/sec ±0.92% (53 runs sampled) (period: 93.60ms)
web-streams-polyfill testCount(113440) x 5.03 ops/sec ±0.77% (28 runs sampled) (period: 198.78ms)
@stardazed/streams testCount(3545) x 835 ops/sec ±1.55% (84 runs sampled) (period: 1.20ms)
@stardazed/streams testCount(7090) x 392 ops/sec ±1.89% (80 runs sampled) (period: 2.55ms)
@stardazed/streams testCount(14180) x 174 ops/sec ±2.63% (78 runs sampled) (period: 5.76ms)
@stardazed/streams testCount(28360) x 73.70 ops/sec ±2.64% (75 runs sampled) (period: 13.57ms)
@stardazed/streams testCount(56720) x 22.85 ops/sec ±5.68% (55 runs sampled) (period: 43.77ms)
@stardazed/streams testCount(113440) x 10.51 ops/sec ±0.91% (52 runs sampled) (period: 95.12ms)
Done

Process finished with exit code 0
```
After:
```
> node --prof index.js

web-streams-polyfill testCount(3545) x 742 ops/sec ±2.47% (79 runs sampled) (period: 1.35ms)
web-streams-polyfill testCount(7090) x 362 ops/sec ±1.06% (80 runs sampled) (period: 2.76ms)
web-streams-polyfill testCount(14180) x 167 ops/sec ±1.25% (75 runs sampled) (period: 6.00ms)
web-streams-polyfill testCount(28360) x 73.14 ops/sec ±0.43% (81 runs sampled) (period: 13.67ms)
web-streams-polyfill testCount(56720) x 23.82 ops/sec ±4.17% (57 runs sampled) (period: 41.97ms)
web-streams-polyfill testCount(113440) x 11.08 ops/sec ±0.95% (54 runs sampled) (period: 90.26ms)
@stardazed/streams testCount(3545) x 819 ops/sec ±1.77% (83 runs sampled) (period: 1.22ms)
@stardazed/streams testCount(7090) x 373 ops/sec ±0.51% (79 runs sampled) (period: 2.68ms)
@stardazed/streams testCount(14180) x 167 ops/sec ±1.84% (82 runs sampled) (period: 5.99ms)
@stardazed/streams testCount(28360) x 71.80 ops/sec ±2.17% (80 runs sampled) (period: 13.93ms)
@stardazed/streams testCount(56720) x 21.08 ops/sec ±5.80% (52 runs sampled) (period: 47.43ms)
@stardazed/streams testCount(113440) x 9.35 ops/sec ±0.62% (47 runs sampled) (period: 106.98ms)
Done

Process finished with exit code 0
```