### PR TITLE
Use optimized queue everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ## Unreleased
 
-* 💅 Improve performance of `ReadableStreamDefaultReader.read()` ([#17](https://github.com/MattiasBuelens/web-streams-polyfill/pull/17))
+* 💅 Improve performance of `reader.read()` and `writer.write()` ([#17](https://github.com/MattiasBuelens/web-streams-polyfill/pull/17), [#18](https://github.com/MattiasBuelens/web-streams-polyfill/pull/18))
 
 ## v2.0.1 (2019-03-16)
 

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -813,8 +813,8 @@ function ReadableStreamClose<R>(stream: ReadableStream<R>): void {
   }
 
   if (IsReadableStreamDefaultReader<R>(reader)) {
-    reader._readRequests.forEach(({ _resolve }) => {
-      _resolve(ReadableStreamCreateReadResult<R>(undefined, true, reader._forAuthorCode));
+    reader._readRequests.forEach(readRequest => {
+      readRequest._resolve(ReadableStreamCreateReadResult<R>(undefined, true, reader._forAuthorCode));
     });
     reader._readRequests = new SimpleQueue();
   }

--- a/src/lib/simple-queue.ts
+++ b/src/lib/simple-queue.ts
@@ -1,26 +1,39 @@
 import assert from '../stub/assert';
 
-const CHUNK_SIZE = 16384;
+// Original from Chromium
+// https://chromium.googlesource.com/chromium/src/+/0aee4434a4dba42a42abaea9bfbc0cd196a63bc1/third_party/blink/renderer/core/streams/SimpleQueue.js
+
+const QUEUE_MAX_ARRAY_SIZE = 16384;
+
+interface Node<T> {
+  _elements: T[];
+  _next: Node<T> | undefined;
+}
 
 /**
  * Simple queue structure.
  *
- * Avoids scalability issues with large arrays in Chrome
- * by using an array of bounded arrays instead.
- *
- * @see https://github.com/MattiasBuelens/web-streams-polyfill/issues/15
+ * Avoids scalability issues with using a packed array directly by using
+ * multiple arrays in a linked list and keeping the array size bounded.
  */
 export class SimpleQueue<T> {
-  private readonly _chunks: T[][];
-  private _front: T[];
-  private _back: T[];
+  private _front: Node<T>;
+  private _back: Node<T>;
+  private _cursor: number = 0;
   private _size: number = 0;
 
   constructor() {
-    const chunk: T[] = [];
-    this._chunks = [chunk];
-    this._front = chunk;
-    this._back = chunk;
+    // _front and _back are always defined.
+    this._front = {
+      _elements: [],
+      _next: undefined
+    };
+    this._back = this._front;
+    // The cursor is used to avoid calling Array.shift().
+    // It contains the index of the front element of the array inside the
+    // front-most node. It is always in the range [0, QUEUE_MAX_ARRAY_SIZE).
+    this._cursor = 0;
+    // When there is only one node, size === elements.length - cursor.
     this._size = 0;
   }
 
@@ -28,34 +41,99 @@ export class SimpleQueue<T> {
     return this._size;
   }
 
+  // For exception safety, this method is structured in order:
+  // 1. Read state
+  // 2. Calculate required state mutations
+  // 3. Perform state mutations
   push(element: T): void {
-    this._back.push(element);
-    ++this._size;
-
-    if (this._back.length === CHUNK_SIZE) {
-      this._back = [];
-      this._chunks.push(this._back);
+    const oldBack = this._back;
+    let newBack = oldBack;
+    assert(oldBack._next === undefined);
+    if (oldBack._elements.length === QUEUE_MAX_ARRAY_SIZE - 1) {
+      newBack = {
+        _elements: [],
+        _next: undefined
+      };
     }
+
+    // push() is the mutation most likely to throw an exception, so it
+    // goes first.
+    oldBack._elements.push(element);
+    if (newBack !== oldBack) {
+      this._back = newBack;
+      oldBack._next = newBack;
+    }
+    ++this._size;
   }
 
+  // Like push(), shift() follows the read -> calculate -> mutate pattern for
+  // exception safety.
   shift(): T {
     assert(this._size > 0); // must not be called on an empty queue
 
-    const element = this._front.shift()!;
-    --this._size;
+    const oldFront = this._front;
+    let newFront = oldFront;
+    const oldCursor = this._cursor;
+    let newCursor = oldCursor + 1;
 
-    if (this._front.length === 0 && this._front !== this._back) {
-      this._chunks.shift();
-      this._front = this._chunks[0];
+    const elements = oldFront._elements;
+    const element = elements[oldCursor];
+
+    if (newCursor === QUEUE_MAX_ARRAY_SIZE) {
+      assert(elements.length === QUEUE_MAX_ARRAY_SIZE);
+      assert(oldFront._next !== undefined);
+      newFront = oldFront._next!;
+      newCursor = 0;
     }
+
+    // No mutations before this point.
+    --this._size;
+    this._cursor = newCursor;
+    if (oldFront !== newFront) {
+      this._front = newFront;
+    }
+
+    // Permit shifted element to be garbage collected.
+    elements[oldCursor] = undefined!;
 
     return element;
   }
 
-  peek(): T {
-    assert(this._size > 0); // must not be called on an empty queue
-
-    return this._front[0];
+  // The tricky thing about forEach() is that it can be called
+  // re-entrantly. The queue may be mutated inside the callback. It is easy to
+  // see that push() within the callback has no negative effects since the end
+  // of the queue is checked for on every iteration. If shift() is called
+  // repeatedly within the callback then the next iteration may return an
+  // element that has been removed. In this case the callback will be called
+  // with undefined values until we either "catch up" with elements that still
+  // exist or reach the back of the queue.
+  forEach(callback: (element: T) => void): void {
+    let i = this._cursor;
+    let node = this._front;
+    let elements = node._elements;
+    while (i !== elements.length || node._next !== undefined) {
+      if (i === elements.length) {
+        assert(node._next !== undefined);
+        assert(i === QUEUE_MAX_ARRAY_SIZE);
+        node = node._next!;
+        elements = node._elements;
+        i = 0;
+        if (elements.length === 0) {
+          break;
+        }
+      }
+      callback(elements[i]);
+      ++i;
+    }
   }
 
+  // Return the element that would be returned if shift() was called now,
+  // without modifying the queue.
+  peek() {
+    assert(this._size > 0); // must not be called on an empty queue
+
+    const front = this._front;
+    const cursor = this._cursor;
+    return front._elements[cursor];
+  }
 }


### PR DESCRIPTION
* Switch to [Chromium's `SimpleQueue` implementation](https://chromium.googlesource.com/chromium/src/+/0aee4434a4dba42a42abaea9bfbc0cd196a63bc1/third_party/blink/renderer/core/streams/SimpleQueue.js) for (slightly) better performance and `.forEach` support.
* Use `SimpleQueue` for:
  * `ReadableStreamDefaultReader._readRequests`
  * `ReadableStreamBYOBReader._readIntoRequests`
  * `ReadableByteStreamController._pendingPullIntos`
  * `WritableStream._writeRequests`

Benchmark before:
```
> node --prof index.js

web-streams-polyfill testCount(3545) x 742 ops/sec ±2.47% (79 runs sampled) (period: 1.35ms)
web-streams-polyfill testCount(7090) x 362 ops/sec ±1.06% (80 runs sampled) (period: 2.76ms)
web-streams-polyfill testCount(14180) x 167 ops/sec ±1.25% (75 runs sampled) (period: 6.00ms)
web-streams-polyfill testCount(28360) x 73.14 ops/sec ±0.43% (81 runs sampled) (period: 13.67ms)
web-streams-polyfill testCount(56720) x 23.82 ops/sec ±4.17% (57 runs sampled) (period: 41.97ms)
web-streams-polyfill testCount(113440) x 11.08 ops/sec ±0.95% (54 runs sampled) (period: 90.26ms)
```
Benchmark after:
```
> node --prof index.js

web-streams-polyfill testCount(3545) x 972 ops/sec ±1.05% (80 runs sampled) (period: 1.03ms)
web-streams-polyfill testCount(7090) x 460 ops/sec ±1.28% (82 runs sampled) (period: 2.17ms)
web-streams-polyfill testCount(14180) x 209 ops/sec ±1.12% (78 runs sampled) (period: 4.79ms)
web-streams-polyfill testCount(28360) x 87.96 ops/sec ±0.51% (79 runs sampled) (period: 11.37ms)
web-streams-polyfill testCount(56720) x 26.73 ops/sec ±4.14% (63 runs sampled) (period: 37.41ms)
web-streams-polyfill testCount(113440) x 12.54 ops/sec ±0.80% (60 runs sampled) (period: 79.73ms)
```