### PR TITLE
Run web platform tests on ES5 build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ## Unreleased
 
+* 🏠 Run web platform tests on ES5 variant ([#19](https://github.com/MattiasBuelens/web-streams-polyfill/pull/19))
+
 ## v2.0.2 (2019-03-17)
 
 * 💅 Improve performance of `reader.read()` and `writer.write()` ([#17](https://github.com/MattiasBuelens/web-streams-polyfill/pull/17), [#18](https://github.com/MattiasBuelens/web-streams-polyfill/pull/18))

--- a/README.md
+++ b/README.md
@@ -68,13 +68,21 @@ The `polyfill/es2018` and `ponyfill/es2018` variants work in any ES2018-compatib
 
 The polyfill implements [version `2c8f35e` (21 Feb 2019)][spec-snapshot] of the streams specification.
 
-The polyfill is tested against the same [web platform tests][wpt] that are used by browsers to test their native implementations. The polyfill aims to pass all tests, although it allows some exceptions for practical reasons:
+The polyfill is tested against the same [web platform tests][wpt] that are used by browsers to test their native implementations.
+The polyfill aims to pass all tests, although it allows some exceptions for practical reasons:
 * The `es2018` variant passes all of the tests, except for the [detached buffer tests for readable byte streams][wpt-detached-buffer].
   These tests require the implementation to synchronously transfer the contents of an `ArrayBuffer`, which is not yet possible from JavaScript (although there is a [proposal][proposal-arraybuffer-transfer] to make it possible).
   The reference implementation "cheats" on these tests [by making a copy instead][ref-impl-transferarraybuffer], but that is unacceptable for the polyfill's performance ([#3][issue-3]).
 * The `es6` variant passes the same tests as the `es2018` variant, except for the [test for the prototype of `ReadableStream`'s async iterator][wpt-async-iterator-prototype].
   Retrieving the correct `%AsyncIteratorPrototype%` requires using an async generator (`async function* () {}`), which is invalid syntax before ES2018.
   Instead, the polyfill [creates its own version][stub-async-iterator-prototype] which is functionally equivalent to the real prototype.
+* The `es5` variant passes the same tests as the `es6` variant, except for various tests about specific characteristics of the constructors, properties and methods.
+  These test failures do not affect the run-time behavior of the polyfill.
+  For example:
+  * The `name` property of down-leveled constructors is incorrect.
+  * The `length` property of down-leveled constructors and methods with optional arguments is incorrect.
+  * Not all properties and methods are correctly marked as non-enumerable.
+  * Down-leveled class methods are not correctly marked as non-constructable.
 
 The type definitions are compatible with the built-in stream types of TypeScript 3.3.
 

--- a/test/run-web-platform-tests.js
+++ b/test/run-web-platform-tests.js
@@ -133,7 +133,7 @@ async function runTests(entryFile, { excludedTests = [], ignoredFailures = {} } 
 
   console.log(`>>> ${entryFile}`);
 
-  let failures = await wptRunner(testsPath, {
+  const wptFailures = await wptRunner(testsPath, {
     rootURL: 'streams/',
     reporter,
     setup(window) {
@@ -151,7 +151,7 @@ async function runTests(entryFile, { excludedTests = [], ignoredFailures = {} } 
   console.log();
   console.log(`${results.passed} tests passed, ${results.failed} failed, ${results.ignored} ignored`);
 
-  failures -= results.ignored;
+  let failures = Math.max(results.failed, wptFailures - results.ignored);
 
   if (rejections.size > 0) {
     if (failures === 0) {

--- a/test/run-web-platform-tests.js
+++ b/test/run-web-platform-tests.js
@@ -51,20 +51,68 @@ async function main() {
     ];
   }
 
+  const ignoredFailuresES6 = {
+    ...ignoredFailures,
+    'readable-streams/async-iterator.any.html': [
+      // ES6 build will not use correct %AsyncIteratorPrototype%
+      'Async iterator instances should have the correct list of properties'
+    ]
+  };
+
+  const ignoredFailuresES5 = {
+    ...ignoredFailuresES6,
+    // ES5 build does not set correct function name on constructors and methods
+    // ES5 build does not set correct length on constructors and methods with optional arguments
+    // ES5 build does not set correct 'enumerable' flag on properties and methods
+    // ES5 build cannot mark methods as non-constructable
+    'byte-length-queuing-strategy.any.html': [
+      'ByteLengthQueuingStrategy.name is correct'
+    ],
+    'count-queuing-strategy.any.html': [
+      'CountQueuingStrategy.name is correct'
+    ],
+    'readable-byte-streams/brand-checks.any.html': [
+      'Can get the ReadableStreamBYOBReader constructor indirectly', // checks name
+      'Can get the ReadableByteStreamController constructor indirectly' // checks name
+    ],
+    'readable-byte-streams/properties.any.html': [
+      'ReadableStreamBYOBReader instances should have the correct list of properties',
+      'ReadableByteStreamController instances should have the correct list of properties',
+      'ReadableStreamBYOBRequest instances should have the correct list of properties'
+    ],
+    'readable-streams/default-reader.any.html': [
+      'ReadableStreamDefaultReader instances should have the correct list of properties'
+    ],
+    'readable-streams/general.any.html': [
+      'ReadableStream instances should have the correct list of properties',
+      'ReadableStream start should be called with the proper parameters'
+    ],
+    'transform-streams/general.any.html': [
+      'TransformStream instances must have writable and readable properties of the correct types'
+    ],
+    'transform-streams/properties.any.html': [
+      /should be a constructor/,
+      /should be a method/,
+      /should have standard properties/
+    ],
+    'writable-streams/properties.any.html': [
+      /should be a constructor/,
+      /should be a method/,
+      /should have standard properties/
+    ]
+  };
+
   let failures = 0;
   if (supportsES2018) {
     failures += await runTests('polyfill.es2018.min.js', { excludedTests, ignoredFailures });
   }
   failures += await runTests('polyfill.es6.min.js', {
     excludedTests,
-    ignoredFailures: {
-      ...ignoredFailures,
-      'readable-streams/async-iterator.any.html': [
-        ...(ignoredFailures['readable-streams/async-iterator.any.html'] || []),
-        // ES6 build will not use correct %AsyncIteratorPrototype%
-        'Async iterator instances should have the correct list of properties'
-      ]
-    }
+    ignoredFailures: ignoredFailuresES6
+  });
+  failures += await runTests('polyfill.min.js', {
+    excludedTests,
+    ignoredFailures: ignoredFailuresES5
   });
 
   process.exitCode = failures;

--- a/test/wpt-util/filtering-reporter.js
+++ b/test/wpt-util/filtering-reporter.js
@@ -21,13 +21,18 @@ class FilteringReporter {
 
   fail(message) {
     const ignoredFailures = this._ignoredFailures[this._currentSuite];
-    if (ignoredFailures && ignoredFailures.includes(message.trim())) {
-      this._ignored++;
-      this._reporter.fail(`${message.trim()} (ignored)\n`);
-    } else {
-      this._failed++;
-      this._reporter.fail(message);
+    if (ignoredFailures) {
+      message = message.trim();
+      for (const ignoredFailure of ignoredFailures) {
+        if (matches(ignoredFailure, message)) {
+          this._ignored++;
+          this._reporter.fail(`${message} (ignored)\n`);
+          return;
+        }
+      }
     }
+    this._failed++;
+    this._reporter.fail(message);
   }
 
   reportStack(stack) {
@@ -41,6 +46,16 @@ class FilteringReporter {
       ignored: this._ignored
     };
   }
+}
+
+function matches(test, input) {
+  if (typeof test === 'string') {
+    return input.includes(test);
+  }
+  if (test instanceof RegExp) {
+    return test.test(input);
+  }
+  return false;
 }
 
 module.exports = {


### PR DESCRIPTION
This extends the test runner to also run WPT against the ES5 polyfill. Expected test failures caused by the (imperfect) down-leveling of ES2015 classes to ES5 are ignored.