### PR TITLE
Update to spec version of 1 April 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Unreleased
 
+* 👓 Align with [spec version `6f94580`](https://github.com/whatwg/streams/tree/6f94580f6731d1e017c516af097d47c45aad1f56/)
 * 🏠 Run web platform tests on ES5 variant ([#19](https://github.com/MattiasBuelens/web-streams-polyfill/pull/19))
 
 ## v2.0.2 (2019-03-17)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `polyfill/es2018` and `ponyfill/es2018` variants work in any ES2018-compatib
 
 ### Compliance
 
-The polyfill implements [version `2c8f35e` (21 Feb 2019)][spec-snapshot] of the streams specification.
+The polyfill implements [version `6f94580` (1 Apr 2019)][spec-snapshot] of the streams specification.
 
 The polyfill is tested against the same [web platform tests][wpt] that are used by browsers to test their native implementations.
 The polyfill aims to pass all tests, although it allows some exceptions for practical reasons:
@@ -99,12 +99,12 @@ Thanks to these people for their work on [the original polyfill][creatorrr-polyf
 [promise-support]: https://kangax.github.io/compat-table/es6/#test-Promise
 [promise-polyfill]: https://www.npmjs.com/package/promise-polyfill
 [rs-asynciterator]: https://streams.spec.whatwg.org/#rs-asynciterator
-[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/2c8f35ed23451ffc9b32ec37b56def4a5349abb1/
-[wpt]: https://github.com/web-platform-tests/wpt/tree/de6f8fcf9b87e80811e9267a886cf891f6f864e0/streams
-[wpt-detached-buffer]: https://github.com/web-platform-tests/wpt/blob/de6f8fcf9b87e80811e9267a886cf891f6f864e0/streams/readable-byte-streams/detached-buffers.any.js
+[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/6f94580f6731d1e017c516af097d47c45aad1f56/
+[wpt]: https://github.com/web-platform-tests/wpt/tree/05e7031bec9a03261cbf112b575a7998b7c76b3c/streams
+[wpt-detached-buffer]: https://github.com/web-platform-tests/wpt/blob/05e7031bec9a03261cbf112b575a7998b7c76b3c/streams/readable-byte-streams/detached-buffers.any.js
 [proposal-arraybuffer-transfer]: https://github.com/domenic/proposal-arraybuffer-transfer
-[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/2c8f35ed23451ffc9b32ec37b56def4a5349abb1/reference-implementation/lib/helpers.js#L119
+[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/6f94580f6731d1e017c516af097d47c45aad1f56/reference-implementation/lib/helpers.js#L119
 [issue-3]: https://github.com/MattiasBuelens/web-streams-polyfill/issues/3
-[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/de6f8fcf9b87e80811e9267a886cf891f6f864e0/streams/readable-streams/async-iterator.any.js#L17
+[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/05e7031bec9a03261cbf112b575a7998b7c76b3c/streams/readable-streams/async-iterator.any.js#L17
 [stub-async-iterator-prototype]: https://github.com/MattiasBuelens/web-streams-polyfill/blob/v2.0.0/src/target/es5/stub/async-iterator-prototype.ts
 [creatorrr-polyfill]: https://github.com/creatorrr/web-streams-polyfill


### PR DESCRIPTION
This aligns the implementation with [spec version `6f94580` of 1 April 2019](https://streams.spec.whatwg.org/commit-snapshots/6f94580f6731d1e017c516af097d47c45aad1f56/).

Comparison: https://github.com/whatwg/streams/compare/2c8f35ed23451ffc9b32ec37b56def4a5349abb1...6f94580f6731d1e017c516af097d47c45aad1f56