### PR TITLE
Update to spec version of 23 August 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ## Unreleased
 
+* 👓 Align with [spec version `ae5e0cb`](https://github.com/whatwg/streams/tree/ae5e0cb41e9f72cdd97f3a6d47bc674c1f4049d1/) ([#33](https://github.com/MattiasBuelens/web-streams-polyfill/pull/33))
+
 ## v2.0.4 (2019-08-01)
 
 * 🐛 Fix pipe not aborting when both `preventAbort` and `preventCancel` are set ([#31](https://github.com/MattiasBuelens/web-streams-polyfill/pull/31))

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `polyfill/es2018` and `ponyfill/es2018` variants work in any ES2018-compatib
 
 ### Compliance
 
-The polyfill implements [version `e4d3b1a` (29 Jul 2019)][spec-snapshot] of the streams specification.
+The polyfill implements [version `ae5e0cb` (23 Aug 2019)][spec-snapshot] of the streams specification.
 
 The polyfill is tested against the same [web platform tests][wpt] that are used by browsers to test their native implementations.
 The polyfill aims to pass all tests, although it allows some exceptions for practical reasons:
@@ -99,12 +99,12 @@ Thanks to these people for their work on [the original polyfill][creatorrr-polyf
 [promise-support]: https://kangax.github.io/compat-table/es6/#test-Promise
 [promise-polyfill]: https://www.npmjs.com/package/promise-polyfill
 [rs-asynciterator]: https://streams.spec.whatwg.org/#rs-asynciterator
-[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/e4d3b1a826e34d27a7cb5485a1cc4b078608c9ec/
-[wpt]: https://github.com/web-platform-tests/wpt/tree/0da3476dcd5fd3148041d090d2330cf8d412d7f9/streams
-[wpt-detached-buffer]: https://github.com/web-platform-tests/wpt/blob/0da3476dcd5fd3148041d090d2330cf8d412d7f9/streams/readable-byte-streams/detached-buffers.any.js
+[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/ae5e0cb41e9f72cdd97f3a6d47bc674c1f4049d1/
+[wpt]: https://github.com/web-platform-tests/wpt/tree/7046bf42a72ef21e5e39267d89dc3e30be6d72e3/streams
+[wpt-detached-buffer]: https://github.com/web-platform-tests/wpt/blob/7046bf42a72ef21e5e39267d89dc3e30be6d72e3/streams/readable-byte-streams/detached-buffers.any.js
 [proposal-arraybuffer-transfer]: https://github.com/domenic/proposal-arraybuffer-transfer
-[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/e4d3b1a826e34d27a7cb5485a1cc4b078608c9ec/reference-implementation/lib/helpers.js#L119
+[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/ae5e0cb41e9f72cdd97f3a6d47bc674c1f4049d1/reference-implementation/lib/helpers.js#L120
 [issue-3]: https://github.com/MattiasBuelens/web-streams-polyfill/issues/3
-[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/0da3476dcd5fd3148041d090d2330cf8d412d7f9/streams/readable-streams/async-iterator.any.js#L17
+[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/7046bf42a72ef21e5e39267d89dc3e30be6d72e3/streams/readable-streams/async-iterator.any.js#L17
 [stub-async-iterator-prototype]: https://github.com/MattiasBuelens/web-streams-polyfill/blob/v2.0.0/src/target/es5/stub/async-iterator-prototype.ts
 [creatorrr-polyfill]: https://github.com/creatorrr/web-streams-polyfill

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -130,7 +130,7 @@ export function PromiseCall<T, A extends any[], R>(F: (this: T, ...args: A) => R
   try {
     return promiseResolvedWith(Call(F, V, args));
   } catch (value) {
-    return Promise.reject(value);
+    return promiseRejectedWith(value);
   }
 }
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -102,7 +102,7 @@ export function CreateAlgorithmFromUnderlyingMethod(underlyingObject: any,
       }
     }
   }
-  return () => Promise.resolve();
+  return () => promiseResolvedWith(undefined);
 }
 
 export function InvokeOrNoop<T, Key extends FunctionPropertyNames<Required<T>> = FunctionPropertyNames<Required<T>>>(
@@ -128,7 +128,7 @@ export function PromiseCall<T, A extends any[], R>(F: (this: T, ...args: A) => R
   assert(V !== undefined);
   assert(Array.isArray(args));
   try {
-    return Promise.resolve(Call(F, V, args));
+    return promiseResolvedWith(Call(F, V, args));
   } catch (value) {
     return Promise.reject(value);
   }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,5 +1,6 @@
 import assert from '../stub/assert';
 import NumberIsNaN from '../stub/number-isnan';
+import { rethrowAssertionErrorRejection } from './utils';
 import { FunctionPropertyNames, InferFirst, InferFunction, InferRest, Promisify } from '../util/type-utils';
 
 function IsPropertyKey(argument: any): argument is string | symbol {
@@ -160,4 +161,63 @@ export function MakeSizeAlgorithmFromSizeFunction<T>(size?: (chunk: T) => number
     throw new TypeError('size property of a queuing strategy must be a function');
   }
   return chunk => size(chunk);
+}
+
+const originalPromise = Promise;
+const originalPromiseThen = Promise.prototype.then;
+const originalPromiseResolve = Promise.resolve.bind(originalPromise);
+const originalPromiseReject = Promise.reject.bind(originalPromise);
+
+export function newPromise<T>(executor: (
+  resolve: (value?: T | PromiseLike<T>) => void,
+  reject: (reason?: any) => void
+) => void): Promise<T> {
+  return new originalPromise(executor);
+}
+
+export function promiseResolvedWith<T>(value: T | PromiseLike<T>): Promise<T> {
+  return originalPromiseResolve(value);
+}
+
+export function promiseRejectedWith<T = never>(reason: any): Promise<T> {
+  return originalPromiseReject(reason);
+}
+
+function PerformPromiseThen<T, TResult1 = T, TResult2 = never>(
+  promise: Promise<T>,
+  onFulfilled?: (value: T) => TResult1 | PromiseLike<TResult1>,
+  onRejected?: (reason: any) => TResult2 | PromiseLike<TResult2>): Promise<TResult1 | TResult2> {
+  // There doesn't appear to be any way to correctly emulate the behaviour from JavaScript, so this is just an
+  // approximation.
+  return originalPromiseThen.call(promise, onFulfilled, onRejected) as Promise<TResult1 | TResult2>;
+}
+
+export function uponPromise<T>(
+  promise: Promise<T>,
+  onFulfilled?: (value: T) => void | PromiseLike<void>,
+  onRejected?: (reason: any) => void | PromiseLike<void>): void {
+  PerformPromiseThen(
+    PerformPromiseThen(promise, onFulfilled, onRejected),
+    undefined,
+    rethrowAssertionErrorRejection
+  );
+}
+
+export function uponFulfillment<T>(promise: Promise<T>, onFulfilled: (value: T) => void | PromiseLike<void>): void {
+  uponPromise(promise, onFulfilled);
+}
+
+export function uponRejection(promise: Promise<unknown>, onRejected: (reason: any) => void | PromiseLike<void>): void {
+  uponPromise(promise, undefined, onRejected);
+}
+
+export function transformPromiseWith<T, TResult1 = T, TResult2 = never>(
+  promise: Promise<T>,
+  fulfillmentHandler?: (value: T) => TResult1 | PromiseLike<TResult1>,
+  rejectionHandler?: (reason: any) => TResult2 | PromiseLike<TResult2>): Promise<TResult1 | TResult2> {
+  return PerformPromiseThen(promise, fulfillmentHandler, rejectionHandler);
+}
+
+export function setPromiseIsHandledToTrue(promise: Promise<unknown>): void {
+  PerformPromiseThen(promise, undefined, rethrowAssertionErrorRejection);
 }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -183,7 +183,7 @@ export function promiseRejectedWith<T = never>(reason: any): Promise<T> {
   return originalPromiseReject(reason);
 }
 
-function PerformPromiseThen<T, TResult1 = T, TResult2 = never>(
+export function PerformPromiseThen<T, TResult1 = T, TResult2 = never>(
   promise: Promise<T>,
   onFulfilled?: (value: T) => TResult1 | PromiseLike<TResult1>,
   onRejected?: (reason: any) => TResult2 | PromiseLike<TResult2>): Promise<TResult1 | TResult2> {

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -8,6 +8,7 @@ import {
   promiseRejectedWith,
   promiseResolvedWith,
   setPromiseIsHandledToTrue,
+  transformPromiseWith,
   typeIsObject,
   ValidateAndNormalizeHighWaterMark
 } from './helpers';
@@ -362,7 +363,7 @@ export function ReadableStreamCancel<R>(stream: ReadableStream<R>, reason: any):
   ReadableStreamClose(stream);
 
   const sourceCancelPromise = stream._readableStreamController[CancelSteps](reason);
-  return sourceCancelPromise.then(() => undefined);
+  return transformPromiseWith(sourceCancelPromise, () => undefined);
 }
 
 export function ReadableStreamClose<R>(stream: ReadableStream<R>): void {

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -58,6 +58,7 @@ import {
   UnderlyingByteSource,
   UnderlyingSource
 } from './readable-stream/underlying-source';
+import { noop } from '../utils';
 
 export type ReadableByteStream = ReadableStream<Uint8Array>;
 
@@ -363,7 +364,7 @@ export function ReadableStreamCancel<R>(stream: ReadableStream<R>, reason: any):
   ReadableStreamClose(stream);
 
   const sourceCancelPromise = stream._readableStreamController[CancelSteps](reason);
-  return transformPromiseWith(sourceCancelPromise, () => undefined);
+  return transformPromiseWith(sourceCancelPromise, noop);
 }
 
 export function ReadableStreamClose<R>(stream: ReadableStream<R>): void {

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -5,6 +5,7 @@ import {
   createArrayFromList,
   IsNonNegativeNumber,
   MakeSizeAlgorithmFromSizeFunction,
+  promiseRejectedWith,
   promiseResolvedWith,
   typeIsObject,
   ValidateAndNormalizeHighWaterMark
@@ -130,11 +131,11 @@ export class ReadableStream<R = any> {
 
   cancel(reason: any): Promise<void> {
     if (IsReadableStream(this) === false) {
-      return Promise.reject(streamBrandCheckException('cancel'));
+      return promiseRejectedWith(streamBrandCheckException('cancel'));
     }
 
     if (IsReadableStreamLocked(this) === true) {
-      return Promise.reject(new TypeError('Cannot cancel a stream that already has a reader'));
+      return promiseRejectedWith(new TypeError('Cannot cancel a stream that already has a reader'));
     }
 
     return ReadableStreamCancel(this, reason);
@@ -199,10 +200,10 @@ export class ReadableStream<R = any> {
   pipeTo(dest: WritableStream<R>,
          { preventClose, preventAbort, preventCancel, signal }: PipeOptions = {}): Promise<void> {
     if (IsReadableStream(this) === false) {
-      return Promise.reject(streamBrandCheckException('pipeTo'));
+      return promiseRejectedWith(streamBrandCheckException('pipeTo'));
     }
     if (IsWritableStream(dest) === false) {
-      return Promise.reject(
+      return promiseRejectedWith(
         new TypeError('ReadableStream.prototype.pipeTo\'s first argument must be a WritableStream'));
     }
 
@@ -211,14 +212,17 @@ export class ReadableStream<R = any> {
     preventCancel = Boolean(preventCancel);
 
     if (signal !== undefined && !isAbortSignal(signal)) {
-      return Promise.reject(new TypeError('ReadableStream.prototype.pipeTo\'s signal option must be an AbortSignal'));
+      return promiseRejectedWith(
+        new TypeError('ReadableStream.prototype.pipeTo\'s signal option must be an AbortSignal'));
     }
 
     if (IsReadableStreamLocked(this) === true) {
-      return Promise.reject(new TypeError('ReadableStream.prototype.pipeTo cannot be used on a locked ReadableStream'));
+      return promiseRejectedWith(
+        new TypeError('ReadableStream.prototype.pipeTo cannot be used on a locked ReadableStream'));
     }
     if (IsWritableStreamLocked(dest) === true) {
-      return Promise.reject(new TypeError('ReadableStream.prototype.pipeTo cannot be used on a locked WritableStream'));
+      return promiseRejectedWith(
+        new TypeError('ReadableStream.prototype.pipeTo cannot be used on a locked WritableStream'));
     }
 
     return ReadableStreamPipeTo(this, dest, preventClose, preventAbort, preventCancel, signal);
@@ -352,7 +356,7 @@ export function ReadableStreamCancel<R>(stream: ReadableStream<R>, reason: any):
     return promiseResolvedWith(undefined);
   }
   if (stream._state === 'errored') {
-    return Promise.reject(stream._storedError);
+    return promiseRejectedWith(stream._storedError);
   }
 
   ReadableStreamClose(stream);

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -7,6 +7,7 @@ import {
   MakeSizeAlgorithmFromSizeFunction,
   promiseRejectedWith,
   promiseResolvedWith,
+  setPromiseIsHandledToTrue,
   typeIsObject,
   ValidateAndNormalizeHighWaterMark
 } from './helpers';
@@ -29,7 +30,6 @@ import { ReadableStreamTee } from './readable-stream/tee';
 import { IsWritableStream, IsWritableStreamLocked, WritableStream } from './writable-stream';
 import NumberIsInteger from '../stub/number-isinteger';
 import { SimpleQueue } from './simple-queue';
-import { noop } from '../utils';
 import {
   AcquireReadableStreamBYOBReader,
   IsReadableStreamBYOBReader,
@@ -192,7 +192,7 @@ export class ReadableStream<R = any> {
 
     const promise = ReadableStreamPipeTo(this, writable, preventClose, preventAbort, preventCancel, signal);
 
-    promise.catch(noop);
+    setPromiseIsHandledToTrue(promise);
 
     return readable;
   }

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -5,6 +5,7 @@ import {
   createArrayFromList,
   IsNonNegativeNumber,
   MakeSizeAlgorithmFromSizeFunction,
+  promiseResolvedWith,
   typeIsObject,
   ValidateAndNormalizeHighWaterMark
 } from './helpers';
@@ -348,7 +349,7 @@ export function ReadableStreamCancel<R>(stream: ReadableStream<R>, reason: any):
   stream._disturbed = true;
 
   if (stream._state === 'closed') {
-    return Promise.resolve(undefined);
+    return promiseResolvedWith(undefined);
   }
   if (stream._state === 'errored') {
     return Promise.reject(stream._storedError);

--- a/src/lib/readable-stream/async-iterator.ts
+++ b/src/lib/readable-stream/async-iterator.ts
@@ -13,7 +13,7 @@ import {
   readerLockException
 } from './generic-reader';
 import assert from '../../stub/assert';
-import { promiseResolvedWith, typeIsObject } from '../helpers';
+import { promiseRejectedWith, promiseResolvedWith, typeIsObject } from '../helpers';
 import { AsyncIteratorPrototype } from '@@target/stub/async-iterator-prototype';
 
 export interface ReadableStreamAsyncIterator<R> extends AsyncIterator<R> {
@@ -36,11 +36,11 @@ declare class ReadableStreamAsyncIteratorImpl<R> implements ReadableStreamAsyncI
 const ReadableStreamAsyncIteratorPrototype: ReadableStreamAsyncIteratorImpl<any> = {
   next(): Promise<IteratorResult<any>> {
     if (IsReadableStreamAsyncIterator(this) === false) {
-      return Promise.reject(streamAsyncIteratorBrandCheckException('next'));
+      return promiseRejectedWith(streamAsyncIteratorBrandCheckException('next'));
     }
     const reader = this._asyncIteratorReader;
     if (reader._ownerReadableStream === undefined) {
-      return Promise.reject(readerLockException('iterate'));
+      return promiseRejectedWith(readerLockException('iterate'));
     }
     return ReadableStreamDefaultReaderRead(reader).then(result => {
       assert(typeIsObject(result));
@@ -56,14 +56,14 @@ const ReadableStreamAsyncIteratorPrototype: ReadableStreamAsyncIteratorImpl<any>
 
   return(value: any): Promise<IteratorResult<any>> {
     if (IsReadableStreamAsyncIterator(this) === false) {
-      return Promise.reject(streamAsyncIteratorBrandCheckException('next'));
+      return promiseRejectedWith(streamAsyncIteratorBrandCheckException('next'));
     }
     const reader = this._asyncIteratorReader;
     if (reader._ownerReadableStream === undefined) {
-      return Promise.reject(readerLockException('finish iterating'));
+      return promiseRejectedWith(readerLockException('finish iterating'));
     }
     if (reader._readRequests.length > 0) {
-      return Promise.reject(new TypeError(
+      return promiseRejectedWith(new TypeError(
         'Tried to release a reader lock when that reader has pending read() calls un-settled'));
     }
     if (this._preventCancel === false) {

--- a/src/lib/readable-stream/async-iterator.ts
+++ b/src/lib/readable-stream/async-iterator.ts
@@ -13,7 +13,7 @@ import {
   readerLockException
 } from './generic-reader';
 import assert from '../../stub/assert';
-import { typeIsObject } from '../helpers';
+import { promiseResolvedWith, typeIsObject } from '../helpers';
 import { AsyncIteratorPrototype } from '@@target/stub/async-iterator-prototype';
 
 export interface ReadableStreamAsyncIterator<R> extends AsyncIterator<R> {
@@ -72,7 +72,7 @@ const ReadableStreamAsyncIteratorPrototype: ReadableStreamAsyncIteratorImpl<any>
       return result.then(() => ReadableStreamCreateReadResult(value, true, true));
     }
     ReadableStreamReaderGenericRelease(reader);
-    return Promise.resolve(ReadableStreamCreateReadResult(value, true, true));
+    return promiseResolvedWith(ReadableStreamCreateReadResult(value, true, true));
   }
 } as any;
 if (AsyncIteratorPrototype !== undefined) {

--- a/src/lib/readable-stream/async-iterator.ts
+++ b/src/lib/readable-stream/async-iterator.ts
@@ -13,7 +13,7 @@ import {
   readerLockException
 } from './generic-reader';
 import assert from '../../stub/assert';
-import { promiseRejectedWith, promiseResolvedWith, typeIsObject } from '../helpers';
+import { promiseRejectedWith, promiseResolvedWith, transformPromiseWith, typeIsObject } from '../helpers';
 import { AsyncIteratorPrototype } from '@@target/stub/async-iterator-prototype';
 
 export interface ReadableStreamAsyncIterator<R> extends AsyncIterator<R> {
@@ -42,7 +42,7 @@ const ReadableStreamAsyncIteratorPrototype: ReadableStreamAsyncIteratorImpl<any>
     if (reader._ownerReadableStream === undefined) {
       return promiseRejectedWith(readerLockException('iterate'));
     }
-    return ReadableStreamDefaultReaderRead(reader).then(result => {
+    return transformPromiseWith(ReadableStreamDefaultReaderRead(reader), result => {
       assert(typeIsObject(result));
       const done = result.done;
       assert(typeof done === 'boolean');
@@ -69,7 +69,7 @@ const ReadableStreamAsyncIteratorPrototype: ReadableStreamAsyncIteratorImpl<any>
     if (this._preventCancel === false) {
       const result = ReadableStreamReaderGenericCancel(reader, value);
       ReadableStreamReaderGenericRelease(reader);
-      return result.then(() => ReadableStreamCreateReadResult(value, true, true));
+      return transformPromiseWith(result, () => ReadableStreamCreateReadResult(value, true, true));
     }
     ReadableStreamReaderGenericRelease(reader);
     return promiseResolvedWith(ReadableStreamCreateReadResult(value, true, true));

--- a/src/lib/readable-stream/byob-reader.ts
+++ b/src/lib/readable-stream/byob-reader.ts
@@ -1,4 +1,4 @@
-import { IsDetachedBuffer, promiseRejectedWith, typeIsObject } from '../helpers';
+import { IsDetachedBuffer, newPromise, promiseRejectedWith, typeIsObject } from '../helpers';
 import assert from '../../stub/assert';
 import { SimpleQueue } from '../simple-queue';
 import {
@@ -31,7 +31,7 @@ export function ReadableStreamAddReadIntoRequest<T extends ArrayBufferView>(stre
   assert(IsReadableStreamBYOBReader(stream._reader) === true);
   assert(stream._state === 'readable' || stream._state === 'closed');
 
-  const promise = new Promise<ReadResult<T>>((resolve, reject) => {
+  const promise = newPromise<ReadResult<T>>((resolve, reject) => {
     const readIntoRequest: ReadIntoRequest<T> = {
       _resolve: resolve,
       _reject: reject

--- a/src/lib/readable-stream/byob-reader.ts
+++ b/src/lib/readable-stream/byob-reader.ts
@@ -1,4 +1,4 @@
-import { IsDetachedBuffer, typeIsObject } from '../helpers';
+import { IsDetachedBuffer, promiseRejectedWith, typeIsObject } from '../helpers';
 import assert from '../../stub/assert';
 import { SimpleQueue } from '../simple-queue';
 import {
@@ -115,7 +115,7 @@ export class ReadableStreamBYOBReader {
 
   get closed(): Promise<void> {
     if (!IsReadableStreamBYOBReader(this)) {
-      return Promise.reject(byobReaderBrandCheckException('closed'));
+      return promiseRejectedWith(byobReaderBrandCheckException('closed'));
     }
 
     return this._closedPromise;
@@ -123,11 +123,11 @@ export class ReadableStreamBYOBReader {
 
   cancel(reason: any): Promise<void> {
     if (!IsReadableStreamBYOBReader(this)) {
-      return Promise.reject(byobReaderBrandCheckException('cancel'));
+      return promiseRejectedWith(byobReaderBrandCheckException('cancel'));
     }
 
     if (this._ownerReadableStream === undefined) {
-      return Promise.reject(readerLockException('cancel'));
+      return promiseRejectedWith(readerLockException('cancel'));
     }
 
     return ReadableStreamReaderGenericCancel(this, reason);
@@ -135,23 +135,23 @@ export class ReadableStreamBYOBReader {
 
   read<T extends ArrayBufferView>(view: T): Promise<ReadResult<T>> {
     if (!IsReadableStreamBYOBReader(this)) {
-      return Promise.reject(byobReaderBrandCheckException('read'));
+      return promiseRejectedWith(byobReaderBrandCheckException('read'));
     }
 
     if (this._ownerReadableStream === undefined) {
-      return Promise.reject(readerLockException('read from'));
+      return promiseRejectedWith(readerLockException('read from'));
     }
 
     if (!ArrayBuffer.isView(view)) {
-      return Promise.reject(new TypeError('view must be an array buffer view'));
+      return promiseRejectedWith(new TypeError('view must be an array buffer view'));
     }
 
     if (IsDetachedBuffer(view.buffer) === true) {
-      return Promise.reject(new TypeError('Cannot read into a view onto a detached ArrayBuffer'));
+      return promiseRejectedWith(new TypeError('Cannot read into a view onto a detached ArrayBuffer'));
     }
 
     if (view.byteLength === 0) {
-      return Promise.reject(new TypeError('view must have non-zero byteLength'));
+      return promiseRejectedWith(new TypeError('view must have non-zero byteLength'));
     }
 
     return ReadableStreamBYOBReaderRead(this, view);
@@ -197,7 +197,7 @@ function ReadableStreamBYOBReaderRead<T extends ArrayBufferView>(reader: Readabl
   stream._disturbed = true;
 
   if (stream._state === 'errored') {
-    return Promise.reject(stream._storedError);
+    return promiseRejectedWith(stream._storedError);
   }
 
   // Controllers must implement this.

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -1,5 +1,4 @@
 import assert from '../../stub/assert';
-import { rethrowAssertionErrorRejection } from '../utils';
 import { SimpleQueue } from '../simple-queue';
 import {
   ArrayBufferCopy,
@@ -11,6 +10,7 @@ import {
   promiseResolvedWith,
   TransferArrayBuffer,
   typeIsObject,
+  uponPromise,
   ValidateAndNormalizeHighWaterMark
 } from '../helpers';
 import { ResetQueue } from '../queue-with-sizes';
@@ -354,7 +354,8 @@ function ReadableByteStreamControllerCallPullIfNeeded(controller: ReadableByteSt
 
   // TODO: Test controller argument
   const pullPromise = controller._pullAlgorithm();
-  pullPromise.then(
+  uponPromise(
+    pullPromise,
     () => {
       controller._pulling = false;
 
@@ -366,7 +367,7 @@ function ReadableByteStreamControllerCallPullIfNeeded(controller: ReadableByteSt
     e => {
       ReadableByteStreamControllerError(controller, e);
     }
-  ).catch(rethrowAssertionErrorRejection);
+  );
 }
 
 function ReadableByteStreamControllerClearPendingPullIntos(controller: ReadableByteStreamController) {
@@ -840,7 +841,8 @@ export function SetUpReadableByteStreamController(stream: ReadableByteStream,
   stream._readableStreamController = controller;
 
   const startResult = startAlgorithm();
-  promiseResolvedWith(startResult).then(
+  uponPromise(
+    promiseResolvedWith(startResult),
     () => {
       controller._started = true;
 
@@ -852,7 +854,7 @@ export function SetUpReadableByteStreamController(stream: ReadableByteStream,
     r => {
       ReadableByteStreamControllerError(controller, r);
     }
-  ).catch(rethrowAssertionErrorRejection);
+  );
 }
 
 export function SetUpReadableByteStreamControllerFromUnderlyingSource(stream: ReadableByteStream,

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -7,6 +7,7 @@ import {
   InvokeOrNoop,
   IsDetachedBuffer,
   IsFiniteNonNegativeNumber,
+  promiseRejectedWith,
   promiseResolvedWith,
   TransferArrayBuffer,
   typeIsObject,
@@ -274,7 +275,7 @@ export class ReadableByteStreamController {
       try {
         view = new Uint8Array(entry.buffer, entry.byteOffset, entry.byteLength);
       } catch (viewE) {
-        return Promise.reject(viewE);
+        return promiseRejectedWith(viewE);
       }
 
       return promiseResolvedWith(ReadableStreamCreateReadResult(view, false, stream._reader!._forAuthorCode));
@@ -286,7 +287,7 @@ export class ReadableByteStreamController {
       try {
         buffer = new ArrayBuffer(autoAllocateChunkSize);
       } catch (bufferE) {
-        return Promise.reject(bufferE);
+        return promiseRejectedWith(bufferE);
       }
 
       const pullIntoDescriptor: DefaultPullIntoDescriptor = {
@@ -562,7 +563,7 @@ export function ReadableByteStreamControllerPullInto<T extends ArrayBufferView>(
       const e = new TypeError('Insufficient bytes to fill elements in the given buffer');
       ReadableByteStreamControllerError(controller, e);
 
-      return Promise.reject(e);
+      return promiseRejectedWith(e);
     }
   }
 

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -7,6 +7,7 @@ import {
   InvokeOrNoop,
   IsDetachedBuffer,
   IsFiniteNonNegativeNumber,
+  promiseResolvedWith,
   TransferArrayBuffer,
   typeIsObject,
   ValidateAndNormalizeHighWaterMark
@@ -276,7 +277,7 @@ export class ReadableByteStreamController {
         return Promise.reject(viewE);
       }
 
-      return Promise.resolve(ReadableStreamCreateReadResult(view, false, stream._reader!._forAuthorCode));
+      return promiseResolvedWith(ReadableStreamCreateReadResult(view, false, stream._reader!._forAuthorCode));
     }
 
     const autoAllocateChunkSize = this._autoAllocateChunkSize;
@@ -545,7 +546,7 @@ export function ReadableByteStreamControllerPullInto<T extends ArrayBufferView>(
 
   if (stream._state === 'closed') {
     const emptyView = new ctor(pullIntoDescriptor.buffer, pullIntoDescriptor.byteOffset, 0);
-    return Promise.resolve(ReadableStreamCreateReadResult(emptyView, true, stream._reader!._forAuthorCode));
+    return promiseResolvedWith(ReadableStreamCreateReadResult(emptyView, true, stream._reader!._forAuthorCode));
   }
 
   if (controller._queueTotalSize > 0) {
@@ -554,7 +555,7 @@ export function ReadableByteStreamControllerPullInto<T extends ArrayBufferView>(
 
       ReadableByteStreamControllerHandleQueueDrain(controller);
 
-      return Promise.resolve(ReadableStreamCreateReadResult(filledView, false, stream._reader!._forAuthorCode));
+      return promiseResolvedWith(ReadableStreamCreateReadResult(filledView, false, stream._reader!._forAuthorCode));
     }
 
     if (controller._closeRequested === true) {
@@ -838,7 +839,7 @@ export function SetUpReadableByteStreamController(stream: ReadableByteStream,
   stream._readableStreamController = controller;
 
   const startResult = startAlgorithm();
-  Promise.resolve(startResult).then(
+  promiseResolvedWith(startResult).then(
     () => {
       controller._started = true;
 

--- a/src/lib/readable-stream/default-controller.ts
+++ b/src/lib/readable-stream/default-controller.ts
@@ -10,7 +10,7 @@ import {
 import { SimpleQueue } from '../simple-queue';
 import { CancelSteps, PullSteps } from './symbols';
 import { ReadableStreamCreateReadResult, ReadResult } from './generic-reader';
-import { CreateAlgorithmFromUnderlyingMethod, InvokeOrNoop, typeIsObject } from '../helpers';
+import { CreateAlgorithmFromUnderlyingMethod, InvokeOrNoop, promiseResolvedWith, typeIsObject } from '../helpers';
 import { IsReadableStreamLocked, ReadableStream, ReadableStreamClose, ReadableStreamError } from '../readable-stream';
 import { UnderlyingSource } from './underlying-source';
 
@@ -107,7 +107,7 @@ export class ReadableStreamDefaultController<R> {
         ReadableStreamDefaultControllerCallPullIfNeeded(this);
       }
 
-      return Promise.resolve(ReadableStreamCreateReadResult(chunk, false, stream._reader!._forAuthorCode));
+      return promiseResolvedWith(ReadableStreamCreateReadResult(chunk, false, stream._reader!._forAuthorCode));
     }
 
     const pendingPromise = ReadableStreamAddReadRequest(stream);
@@ -308,7 +308,7 @@ export function SetUpReadableStreamDefaultController<R>(stream: ReadableStream<R
   stream._readableStreamController = controller;
 
   const startResult = startAlgorithm();
-  Promise.resolve(startResult).then(
+  promiseResolvedWith(startResult).then(
     () => {
       controller._started = true;
 

--- a/src/lib/readable-stream/default-controller.ts
+++ b/src/lib/readable-stream/default-controller.ts
@@ -1,7 +1,6 @@
 import { QueuingStrategySizeCallback } from '../queuing-strategy';
 import assert from '../../stub/assert';
 import { DequeueValue, EnqueueValueWithSize, QueuePair, ResetQueue } from '../queue-with-sizes';
-import { rethrowAssertionErrorRejection } from '../utils';
 import {
   ReadableStreamAddReadRequest,
   ReadableStreamFulfillReadRequest,
@@ -10,7 +9,13 @@ import {
 import { SimpleQueue } from '../simple-queue';
 import { CancelSteps, PullSteps } from './symbols';
 import { ReadableStreamCreateReadResult, ReadResult } from './generic-reader';
-import { CreateAlgorithmFromUnderlyingMethod, InvokeOrNoop, promiseResolvedWith, typeIsObject } from '../helpers';
+import {
+  CreateAlgorithmFromUnderlyingMethod,
+  InvokeOrNoop,
+  promiseResolvedWith,
+  typeIsObject,
+  uponPromise
+} from '../helpers';
 import { IsReadableStreamLocked, ReadableStream, ReadableStreamClose, ReadableStreamError } from '../readable-stream';
 import { UnderlyingSource } from './underlying-source';
 
@@ -146,7 +151,8 @@ function ReadableStreamDefaultControllerCallPullIfNeeded(controller: ReadableStr
   controller._pulling = true;
 
   const pullPromise = controller._pullAlgorithm();
-  pullPromise.then(
+  uponPromise(
+    pullPromise,
     () => {
       controller._pulling = false;
 
@@ -158,7 +164,7 @@ function ReadableStreamDefaultControllerCallPullIfNeeded(controller: ReadableStr
     e => {
       ReadableStreamDefaultControllerError(controller, e);
     }
-  ).catch(rethrowAssertionErrorRejection);
+  );
 }
 
 function ReadableStreamDefaultControllerShouldCallPull(controller: ReadableStreamDefaultController<any>): boolean {
@@ -308,7 +314,8 @@ export function SetUpReadableStreamDefaultController<R>(stream: ReadableStream<R
   stream._readableStreamController = controller;
 
   const startResult = startAlgorithm();
-  promiseResolvedWith(startResult).then(
+  uponPromise(
+    promiseResolvedWith(startResult),
     () => {
       controller._started = true;
 
@@ -320,7 +327,7 @@ export function SetUpReadableStreamDefaultController<R>(stream: ReadableStream<R
     r => {
       ReadableStreamDefaultControllerError(controller, r);
     }
-  ).catch(rethrowAssertionErrorRejection);
+  );
 }
 
 export function SetUpReadableStreamDefaultControllerFromUnderlyingSource<R>(stream: ReadableStream<R>,

--- a/src/lib/readable-stream/default-reader.ts
+++ b/src/lib/readable-stream/default-reader.ts
@@ -1,4 +1,4 @@
-import { promiseResolvedWith, typeIsObject } from '../helpers';
+import { promiseRejectedWith, promiseResolvedWith, typeIsObject } from '../helpers';
 import assert from '../../stub/assert';
 import { SimpleQueue } from '../simple-queue';
 import {
@@ -104,7 +104,7 @@ export class ReadableStreamDefaultReader<R> {
 
   get closed(): Promise<void> {
     if (!IsReadableStreamDefaultReader(this)) {
-      return Promise.reject(defaultReaderBrandCheckException('closed'));
+      return promiseRejectedWith(defaultReaderBrandCheckException('closed'));
     }
 
     return this._closedPromise;
@@ -112,11 +112,11 @@ export class ReadableStreamDefaultReader<R> {
 
   cancel(reason: any): Promise<void> {
     if (!IsReadableStreamDefaultReader(this)) {
-      return Promise.reject(defaultReaderBrandCheckException('cancel'));
+      return promiseRejectedWith(defaultReaderBrandCheckException('cancel'));
     }
 
     if (this._ownerReadableStream === undefined) {
-      return Promise.reject(readerLockException('cancel'));
+      return promiseRejectedWith(readerLockException('cancel'));
     }
 
     return ReadableStreamReaderGenericCancel(this, reason);
@@ -124,11 +124,11 @@ export class ReadableStreamDefaultReader<R> {
 
   read(): Promise<ReadResult<R>> {
     if (!IsReadableStreamDefaultReader(this)) {
-      return Promise.reject(defaultReaderBrandCheckException('read'));
+      return promiseRejectedWith(defaultReaderBrandCheckException('read'));
     }
 
     if (this._ownerReadableStream === undefined) {
-      return Promise.reject(readerLockException('read from'));
+      return promiseRejectedWith(readerLockException('read from'));
     }
 
     return ReadableStreamDefaultReaderRead<R>(this);
@@ -177,7 +177,7 @@ export function ReadableStreamDefaultReaderRead<R>(reader: ReadableStreamDefault
   }
 
   if (stream._state === 'errored') {
-    return Promise.reject(stream._storedError);
+    return promiseRejectedWith(stream._storedError);
   }
 
   assert(stream._state === 'readable');

--- a/src/lib/readable-stream/default-reader.ts
+++ b/src/lib/readable-stream/default-reader.ts
@@ -1,4 +1,4 @@
-import { typeIsObject } from '../helpers';
+import { promiseResolvedWith, typeIsObject } from '../helpers';
 import assert from '../../stub/assert';
 import { SimpleQueue } from '../simple-queue';
 import {
@@ -173,7 +173,7 @@ export function ReadableStreamDefaultReaderRead<R>(reader: ReadableStreamDefault
   stream._disturbed = true;
 
   if (stream._state === 'closed') {
-    return Promise.resolve(ReadableStreamCreateReadResult<R>(undefined, true, reader._forAuthorCode));
+    return promiseResolvedWith(ReadableStreamCreateReadResult<R>(undefined, true, reader._forAuthorCode));
   }
 
   if (stream._state === 'errored') {

--- a/src/lib/readable-stream/default-reader.ts
+++ b/src/lib/readable-stream/default-reader.ts
@@ -1,4 +1,4 @@
-import { promiseRejectedWith, promiseResolvedWith, typeIsObject } from '../helpers';
+import { newPromise, promiseRejectedWith, promiseResolvedWith, typeIsObject } from '../helpers';
 import assert from '../../stub/assert';
 import { SimpleQueue } from '../simple-queue';
 import {
@@ -27,7 +27,7 @@ export function ReadableStreamAddReadRequest<R>(stream: ReadableStream<R>): Prom
   assert(IsReadableStreamDefaultReader(stream._reader) === true);
   assert(stream._state === 'readable');
 
-  const promise = new Promise<ReadResult<R>>((resolve, reject) => {
+  const promise = newPromise<ReadResult<R>>((resolve, reject) => {
     const readRequest: ReadRequest<R> = {
       _resolve: resolve,
       _reject: reject

--- a/src/lib/readable-stream/generic-reader.ts
+++ b/src/lib/readable-stream/generic-reader.ts
@@ -1,6 +1,7 @@
 import assert from '../../stub/assert';
 import { noop } from '../../utils';
 import { ReadableStream, ReadableStreamCancel, ReadableStreamReader } from '../readable-stream';
+import { newPromise } from '../helpers';
 
 // TODO Fix ReadableStreamReadResult<R> in TypeScript DOM types
 export interface ReadResult<T = any> {
@@ -74,7 +75,7 @@ export function readerLockException(name: string): TypeError {
 // Helper functions for the ReadableStreamDefaultReader.
 
 export function defaultReaderClosedPromiseInitialize(reader: ReadableStreamReader<any>) {
-  reader._closedPromise = new Promise((resolve, reject) => {
+  reader._closedPromise = newPromise((resolve, reject) => {
     reader._closedPromise_resolve = resolve;
     reader._closedPromise_reject = reject;
   });

--- a/src/lib/readable-stream/generic-reader.ts
+++ b/src/lib/readable-stream/generic-reader.ts
@@ -1,7 +1,6 @@
 import assert from '../../stub/assert';
-import { noop } from '../../utils';
 import { ReadableStream, ReadableStreamCancel, ReadableStreamReader } from '../readable-stream';
-import { newPromise } from '../helpers';
+import { newPromise, setPromiseIsHandledToTrue } from '../helpers';
 
 // TODO Fix ReadableStreamReadResult<R> in TypeScript DOM types
 export interface ReadResult<T = any> {
@@ -95,7 +94,7 @@ export function defaultReaderClosedPromiseReject(reader: ReadableStreamReader<an
   assert(reader._closedPromise_resolve !== undefined);
   assert(reader._closedPromise_reject !== undefined);
 
-  reader._closedPromise.catch(noop);
+  setPromiseIsHandledToTrue(reader._closedPromise);
   reader._closedPromise_reject!(reason);
   reader._closedPromise_resolve = undefined;
   reader._closedPromise_reject = undefined;

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -28,6 +28,7 @@ import {
   uponPromise,
   uponRejection
 } from '../helpers';
+import { noop } from '../../utils';
 
 export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
                                         dest: WritableStream<T>,
@@ -115,7 +116,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
             return true;
           }
 
-          currentWrite = PerformPromiseThen(WritableStreamDefaultWriterWrite(writer, value), undefined, () => {});
+          currentWrite = PerformPromiseThen(WritableStreamDefaultWriterWrite(writer, value), undefined, noop);
           return false;
         });
       });

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -21,6 +21,7 @@ import {
 import assert from '../../stub/assert';
 import { rethrowAssertionErrorRejection } from '../utils';
 import { noop } from '../../utils';
+import { promiseResolvedWith } from '../helpers';
 
 export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
                                         dest: WritableStream<T>,
@@ -43,7 +44,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
   let shuttingDown = false;
 
   // This is used to keep track of the spec's requirement that we wait for ongoing writes during shutdown.
-  let currentWrite = Promise.resolve();
+  let currentWrite = promiseResolvedWith<void>(undefined);
 
   return new Promise((resolve, reject) => {
     let abortAlgorithm: () => void;
@@ -56,7 +57,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
             if (dest._state === 'writable') {
               return WritableStreamAbort(dest, error);
             }
-            return Promise.resolve();
+            return promiseResolvedWith(undefined);
           });
         }
         if (preventCancel === false) {
@@ -64,7 +65,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
             if (source._state === 'readable') {
               return ReadableStreamCancel(source, error);
             }
-            return Promise.resolve();
+            return promiseResolvedWith(undefined);
           });
         }
         shutdownWithAction(() => Promise.all(actions.map(action => action())), true, error);
@@ -97,7 +98,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
 
     function pipeStep(): Promise<boolean> {
       if (shuttingDown === true) {
-        return Promise.resolve(true);
+        return promiseResolvedWith(true);
       }
 
       return writer._readyPromise.then(() => {

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -20,7 +20,7 @@ import {
 } from '../writable-stream';
 import assert from '../../stub/assert';
 import { rethrowAssertionErrorRejection } from '../utils';
-import { newPromise, promiseResolvedWith } from '../helpers';
+import { newPromise, promiseResolvedWith, setPromiseIsHandledToTrue } from '../helpers';
 import { noop } from '../../utils';
 
 export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
@@ -151,7 +151,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
       }
     }
 
-    pipeLoop().catch(rethrowAssertionErrorRejection);
+    setPromiseIsHandledToTrue(pipeLoop());
 
     function waitForWritesToFinish(): Promise<void> {
       // Another write may have started while we were waiting on this currentWrite, so we have to be sure to wait

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -20,8 +20,8 @@ import {
 } from '../writable-stream';
 import assert from '../../stub/assert';
 import { rethrowAssertionErrorRejection } from '../utils';
+import { newPromise, promiseResolvedWith } from '../helpers';
 import { noop } from '../../utils';
-import { promiseResolvedWith } from '../helpers';
 
 export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
                                         dest: WritableStream<T>,
@@ -46,7 +46,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
   // This is used to keep track of the spec's requirement that we wait for ongoing writes during shutdown.
   let currentWrite = promiseResolvedWith<void>(undefined);
 
-  return new Promise((resolve, reject) => {
+  return newPromise((resolve, reject) => {
     let abortAlgorithm: () => void;
     if (signal !== undefined) {
       abortAlgorithm = () => {
@@ -83,7 +83,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
     // - Backpressure must be enforced
     // - Shutdown must stop all activity
     function pipeLoop() {
-      return new Promise<void>((resolveLoop, rejectLoop) => {
+      return newPromise<void>((resolveLoop, rejectLoop) => {
         function next(done: boolean) {
           if (done) {
             resolveLoop();

--- a/src/lib/readable-stream/tee.ts
+++ b/src/lib/readable-stream/tee.ts
@@ -6,6 +6,7 @@ import {
   newPromise,
   promiseResolvedWith,
   setPromiseIsHandledToTrue,
+  transformPromiseWith,
   typeIsObject
 } from '../helpers';
 import {
@@ -42,7 +43,7 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
 
     reading = true;
 
-    const readPromise = ReadableStreamDefaultReaderRead(reader).then(result => {
+    const readPromise = transformPromiseWith(ReadableStreamDefaultReaderRead(reader), result => {
       reading = false;
 
       assert(typeIsObject(result));

--- a/src/lib/readable-stream/tee.ts
+++ b/src/lib/readable-stream/tee.ts
@@ -1,8 +1,13 @@
 import { CreateReadableStream, IsReadableStream, ReadableStream, ReadableStreamCancel } from '../readable-stream';
 import { AcquireReadableStreamDefaultReader, ReadableStreamDefaultReaderRead } from './default-reader';
 import assert from '../../stub/assert';
-import { createArrayFromList, newPromise, promiseResolvedWith, typeIsObject } from '../helpers';
-import { rethrowAssertionErrorRejection } from '../utils';
+import {
+  createArrayFromList,
+  newPromise,
+  promiseResolvedWith,
+  setPromiseIsHandledToTrue,
+  typeIsObject
+} from '../helpers';
 import {
   ReadableStreamDefaultController,
   ReadableStreamDefaultControllerClose,
@@ -79,7 +84,7 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
       }
     });
 
-    readPromise.catch(rethrowAssertionErrorRejection);
+    setPromiseIsHandledToTrue(readPromise);
 
     return promiseResolvedWith(undefined);
   }

--- a/src/lib/readable-stream/tee.ts
+++ b/src/lib/readable-stream/tee.ts
@@ -7,7 +7,8 @@ import {
   promiseResolvedWith,
   setPromiseIsHandledToTrue,
   transformPromiseWith,
-  typeIsObject
+  typeIsObject,
+  uponRejection
 } from '../helpers';
 import {
   ReadableStreamDefaultController,
@@ -117,7 +118,7 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
   branch1 = CreateReadableStream(startAlgorithm, pullAlgorithm, cancel1Algorithm);
   branch2 = CreateReadableStream(startAlgorithm, pullAlgorithm, cancel2Algorithm);
 
-  reader._closedPromise.catch((r: any) => {
+  uponRejection(reader._closedPromise, (r: any) => {
     ReadableStreamDefaultControllerError(branch1._readableStreamController as ReadableStreamDefaultController<R>, r);
     ReadableStreamDefaultControllerError(branch2._readableStreamController as ReadableStreamDefaultController<R>, r);
   });

--- a/src/lib/readable-stream/tee.ts
+++ b/src/lib/readable-stream/tee.ts
@@ -1,7 +1,7 @@
 import { CreateReadableStream, IsReadableStream, ReadableStream, ReadableStreamCancel } from '../readable-stream';
 import { AcquireReadableStreamDefaultReader, ReadableStreamDefaultReaderRead } from './default-reader';
 import assert from '../../stub/assert';
-import { createArrayFromList, typeIsObject } from '../helpers';
+import { createArrayFromList, promiseResolvedWith, typeIsObject } from '../helpers';
 import { rethrowAssertionErrorRejection } from '../utils';
 import {
   ReadableStreamDefaultController,
@@ -32,7 +32,7 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
 
   function pullAlgorithm(): Promise<void> {
     if (reading === true) {
-      return Promise.resolve();
+      return promiseResolvedWith(undefined);
     }
 
     reading = true;
@@ -81,7 +81,7 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
 
     readPromise.catch(rethrowAssertionErrorRejection);
 
-    return Promise.resolve();
+    return promiseResolvedWith(undefined);
   }
 
   function cancel1Algorithm(reason: any): Promise<void> {

--- a/src/lib/readable-stream/tee.ts
+++ b/src/lib/readable-stream/tee.ts
@@ -1,7 +1,7 @@
 import { CreateReadableStream, IsReadableStream, ReadableStream, ReadableStreamCancel } from '../readable-stream';
 import { AcquireReadableStreamDefaultReader, ReadableStreamDefaultReaderRead } from './default-reader';
 import assert from '../../stub/assert';
-import { createArrayFromList, promiseResolvedWith, typeIsObject } from '../helpers';
+import { createArrayFromList, newPromise, promiseResolvedWith, typeIsObject } from '../helpers';
 import { rethrowAssertionErrorRejection } from '../utils';
 import {
   ReadableStreamDefaultController,
@@ -26,7 +26,7 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
   let branch2: ReadableStream<R>;
 
   let resolveCancelPromise: (reason: any) => void;
-  const cancelPromise = new Promise<any>(resolve => {
+  const cancelPromise = newPromise<any>(resolve => {
     resolveCancelPromise = resolve;
   });
 

--- a/src/lib/transform-stream.ts
+++ b/src/lib/transform-stream.ts
@@ -456,7 +456,7 @@ function TransformStreamDefaultSinkCloseAlgorithm<I, O>(stream: TransformStream<
     if (ReadableStreamDefaultControllerCanCloseOrEnqueue(readableController) === true) {
       ReadableStreamDefaultControllerClose(readableController);
     }
-  }).catch(r => {
+  }, r => {
     TransformStreamError(stream, r);
     throw readable._storedError;
   });

--- a/src/lib/transform-stream.ts
+++ b/src/lib/transform-stream.ts
@@ -5,6 +5,7 @@ import {
   IsNonNegativeNumber,
   MakeSizeAlgorithmFromSizeFunction,
   PromiseCall,
+  promiseResolvedWith,
   typeIsObject,
   ValidateAndNormalizeHighWaterMark
 } from './helpers';
@@ -179,7 +180,7 @@ function InitializeTransformStream<I, O>(stream: TransformStream<I, O>,
 
   function cancelAlgorithm(reason: any): Promise<void> {
     TransformStreamErrorWritableAndUnblockWrite(stream, reason);
-    return Promise.resolve();
+    return promiseResolvedWith(undefined);
   }
 
   stream._readable = CreateReadableStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, readableHighWaterMark,
@@ -328,7 +329,7 @@ function SetUpTransformStreamDefaultControllerFromTransformer<I, O>(stream: Tran
   let transformAlgorithm = (chunk: I) => {
     try {
       TransformStreamDefaultControllerEnqueue(controller, chunk as unknown as O);
-      return Promise.resolve();
+      return promiseResolvedWith<void>(undefined);
     } catch (transformResultE) {
       return Promise.reject(transformResultE);
     }
@@ -432,7 +433,7 @@ function TransformStreamDefaultSinkAbortAlgorithm(stream: TransformStream, reaso
   // abort() is not called synchronously, so it is possible for abort() to be called when the stream is already
   // errored.
   TransformStreamError(stream, reason);
-  return Promise.resolve();
+  return promiseResolvedWith(undefined);
 }
 
 function TransformStreamDefaultSinkCloseAlgorithm<I, O>(stream: TransformStream<I, O>): Promise<void> {

--- a/src/lib/transform-stream.ts
+++ b/src/lib/transform-stream.ts
@@ -4,6 +4,7 @@ import {
   InvokeOrNoop,
   IsNonNegativeNumber,
   MakeSizeAlgorithmFromSizeFunction,
+  newPromise,
   PromiseCall,
   promiseRejectedWith,
   promiseResolvedWith,
@@ -88,7 +89,7 @@ export class TransformStream<I = any, O = any> {
     readableHighWaterMark = ValidateAndNormalizeHighWaterMark(readableHighWaterMark);
 
     let startPromise_resolve!: (value: void | PromiseLike<void>) => void;
-    const startPromise = new Promise<void>(resolve => {
+    const startPromise = newPromise<void>(resolve => {
       startPromise_resolve = resolve;
     });
 
@@ -134,7 +135,7 @@ export function CreateTransformStream<I, O>(startAlgorithm: () => void | Promise
   const stream: TransformStream<I, O> = Object.create(TransformStream.prototype);
 
   let startPromise_resolve!: (value: void | PromiseLike<void>) => void;
-  const startPromise = new Promise<void>(resolve => {
+  const startPromise = newPromise<void>(resolve => {
     startPromise_resolve = resolve;
   });
 
@@ -235,7 +236,7 @@ function TransformStreamSetBackpressure(stream: TransformStream, backpressure: b
     stream._backpressureChangePromise_resolve();
   }
 
-  stream._backpressureChangePromise = new Promise(resolve => {
+  stream._backpressureChangePromise = newPromise(resolve => {
     stream._backpressureChangePromise_resolve = resolve;
   });
 

--- a/src/lib/transform-stream.ts
+++ b/src/lib/transform-stream.ts
@@ -5,6 +5,7 @@ import {
   IsNonNegativeNumber,
   MakeSizeAlgorithmFromSizeFunction,
   PromiseCall,
+  promiseRejectedWith,
   promiseResolvedWith,
   typeIsObject,
   ValidateAndNormalizeHighWaterMark
@@ -331,7 +332,7 @@ function SetUpTransformStreamDefaultControllerFromTransformer<I, O>(stream: Tran
       TransformStreamDefaultControllerEnqueue(controller, chunk as unknown as O);
       return promiseResolvedWith<void>(undefined);
     } catch (transformResultE) {
-      return Promise.reject(transformResultE);
+      return promiseRejectedWith(transformResultE);
     }
   };
   const transformMethod = transformer.transform;

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -4,6 +4,7 @@ import {
   InvokeOrNoop,
   IsNonNegativeNumber,
   MakeSizeAlgorithmFromSizeFunction,
+  promiseRejectedWith,
   promiseResolvedWith,
   typeIsObject,
   ValidateAndNormalizeHighWaterMark
@@ -103,11 +104,11 @@ class WritableStream<W = any> {
 
   abort(reason: any): Promise<void> {
     if (IsWritableStream(this) === false) {
-      return Promise.reject(streamBrandCheckException('abort'));
+      return promiseRejectedWith(streamBrandCheckException('abort'));
     }
 
     if (IsWritableStreamLocked(this) === true) {
-      return Promise.reject(new TypeError('Cannot abort a stream that already has a writer'));
+      return promiseRejectedWith(new TypeError('Cannot abort a stream that already has a writer'));
     }
 
     return WritableStreamAbort(this, reason);
@@ -524,7 +525,7 @@ class WritableStreamDefaultWriter<W> {
 
   get closed(): Promise<void> {
     if (IsWritableStreamDefaultWriter(this) === false) {
-      return Promise.reject(defaultWriterBrandCheckException('closed'));
+      return promiseRejectedWith(defaultWriterBrandCheckException('closed'));
     }
 
     return this._closedPromise;
@@ -544,7 +545,7 @@ class WritableStreamDefaultWriter<W> {
 
   get ready(): Promise<void> {
     if (IsWritableStreamDefaultWriter(this) === false) {
-      return Promise.reject(defaultWriterBrandCheckException('ready'));
+      return promiseRejectedWith(defaultWriterBrandCheckException('ready'));
     }
 
     return this._readyPromise;
@@ -552,11 +553,11 @@ class WritableStreamDefaultWriter<W> {
 
   abort(reason: any): Promise<void> {
     if (IsWritableStreamDefaultWriter(this) === false) {
-      return Promise.reject(defaultWriterBrandCheckException('abort'));
+      return promiseRejectedWith(defaultWriterBrandCheckException('abort'));
     }
 
     if (this._ownerWritableStream === undefined) {
-      return Promise.reject(defaultWriterLockException('abort'));
+      return promiseRejectedWith(defaultWriterLockException('abort'));
     }
 
     return WritableStreamDefaultWriterAbort(this, reason);
@@ -564,17 +565,17 @@ class WritableStreamDefaultWriter<W> {
 
   close(): Promise<void> {
     if (IsWritableStreamDefaultWriter(this) === false) {
-      return Promise.reject(defaultWriterBrandCheckException('close'));
+      return promiseRejectedWith(defaultWriterBrandCheckException('close'));
     }
 
     const stream = this._ownerWritableStream;
 
     if (stream === undefined) {
-      return Promise.reject(defaultWriterLockException('close'));
+      return promiseRejectedWith(defaultWriterLockException('close'));
     }
 
     if (WritableStreamCloseQueuedOrInFlight(stream) === true) {
-      return Promise.reject(new TypeError('cannot close an already-closing stream'));
+      return promiseRejectedWith(new TypeError('cannot close an already-closing stream'));
     }
 
     return WritableStreamDefaultWriterClose(this);
@@ -598,11 +599,11 @@ class WritableStreamDefaultWriter<W> {
 
   write(chunk: W): Promise<void> {
     if (IsWritableStreamDefaultWriter(this) === false) {
-      return Promise.reject(defaultWriterBrandCheckException('write'));
+      return promiseRejectedWith(defaultWriterBrandCheckException('write'));
     }
 
     if (this._ownerWritableStream === undefined) {
-      return Promise.reject(defaultWriterLockException('write to'));
+      return promiseRejectedWith(defaultWriterLockException('write to'));
     }
 
     return WritableStreamDefaultWriterWrite(this, chunk);
@@ -640,7 +641,7 @@ function WritableStreamDefaultWriterClose(writer: WritableStreamDefaultWriter<an
 
   const state = stream._state;
   if (state === 'closed' || state === 'errored') {
-    return Promise.reject(new TypeError(
+    return promiseRejectedWith(new TypeError(
       `The stream (in ${state} state) is not in the writable state and cannot be closed`));
   }
 
@@ -677,7 +678,7 @@ function WritableStreamDefaultWriterCloseWithErrorPropagation(writer: WritableSt
   }
 
   if (state === 'errored') {
-    return Promise.reject(stream._storedError);
+    return promiseRejectedWith(stream._storedError);
   }
 
   assert(state === 'writable' || state === 'erroring');
@@ -744,18 +745,18 @@ function WritableStreamDefaultWriterWrite<W>(writer: WritableStreamDefaultWriter
   const chunkSize = WritableStreamDefaultControllerGetChunkSize(controller, chunk);
 
   if (stream !== writer._ownerWritableStream) {
-    return Promise.reject(defaultWriterLockException('write to'));
+    return promiseRejectedWith(defaultWriterLockException('write to'));
   }
 
   const state = stream._state;
   if (state === 'errored') {
-    return Promise.reject(stream._storedError);
+    return promiseRejectedWith(stream._storedError);
   }
   if (WritableStreamCloseQueuedOrInFlight(stream) === true || state === 'closed') {
-    return Promise.reject(new TypeError('The stream is closing or closed and cannot be written to'));
+    return promiseRejectedWith(new TypeError('The stream is closing or closed and cannot be written to'));
   }
   if (state === 'erroring') {
-    return Promise.reject(stream._storedError);
+    return promiseRejectedWith(stream._storedError);
   }
 
   assert(state === 'writable');

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -4,6 +4,7 @@ import {
   InvokeOrNoop,
   IsNonNegativeNumber,
   MakeSizeAlgorithmFromSizeFunction,
+  promiseResolvedWith,
   typeIsObject,
   ValidateAndNormalizeHighWaterMark
 } from './helpers';
@@ -221,7 +222,7 @@ function IsWritableStreamLocked(stream: WritableStream): boolean {
 function WritableStreamAbort(stream: WritableStream, reason: any): Promise<void> {
   const state = stream._state;
   if (state === 'closed' || state === 'errored') {
-    return Promise.resolve(undefined);
+    return promiseResolvedWith(undefined);
   }
   if (stream._pendingAbortRequest !== undefined) {
     return stream._pendingAbortRequest._promise;
@@ -672,7 +673,7 @@ function WritableStreamDefaultWriterCloseWithErrorPropagation(writer: WritableSt
 
   const state = stream._state;
   if (WritableStreamCloseQueuedOrInFlight(stream) === true || state === 'closed') {
-    return Promise.resolve();
+    return promiseResolvedWith(undefined);
   }
 
   if (state === 'errored') {
@@ -873,7 +874,7 @@ function SetUpWritableStreamDefaultController<W>(stream: WritableStream<W>,
   WritableStreamUpdateBackpressure(stream, backpressure);
 
   const startResult = startAlgorithm();
-  const startPromise = Promise.resolve(startResult);
+  const startPromise = promiseResolvedWith(startResult);
   startPromise.then(
     () => {
       assert(stream._state === 'writable' || stream._state === 'erroring');

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -4,6 +4,7 @@ import {
   InvokeOrNoop,
   IsNonNegativeNumber,
   MakeSizeAlgorithmFromSizeFunction,
+  newPromise,
   promiseRejectedWith,
   promiseResolvedWith,
   typeIsObject,
@@ -238,7 +239,7 @@ function WritableStreamAbort(stream: WritableStream, reason: any): Promise<void>
     reason = undefined;
   }
 
-  const promise = new Promise<void>((resolve, reject) => {
+  const promise = newPromise<void>((resolve, reject) => {
     stream._pendingAbortRequest = {
       _promise: undefined!,
       _resolve: resolve,
@@ -262,7 +263,7 @@ function WritableStreamAddWriteRequest(stream: WritableStream): Promise<void> {
   assert(IsWritableStreamLocked(stream) === true);
   assert(stream._state === 'writable');
 
-  const promise = new Promise<void>((resolve, reject) => {
+  const promise = newPromise<void>((resolve, reject) => {
     const writeRequest: WriteRequest = {
       _resolve: resolve,
       _reject: reject
@@ -648,7 +649,7 @@ function WritableStreamDefaultWriterClose(writer: WritableStreamDefaultWriter<an
   assert(state === 'writable' || state === 'erroring');
   assert(WritableStreamCloseQueuedOrInFlight(stream) === false);
 
-  const promise = new Promise<void>((resolve, reject) => {
+  const promise = newPromise<void>((resolve, reject) => {
     const closeRequest: CloseRequest = {
       _resolve: resolve,
       _reject: reject
@@ -1087,7 +1088,7 @@ function defaultWriterLockException(name: string): TypeError {
 }
 
 function defaultWriterClosedPromiseInitialize(writer: WritableStreamDefaultWriter<any>) {
-  writer._closedPromise = new Promise((resolve, reject) => {
+  writer._closedPromise = newPromise((resolve, reject) => {
     writer._closedPromise_resolve = resolve;
     writer._closedPromise_reject = reject;
     writer._closedPromiseState = 'pending';
@@ -1136,7 +1137,7 @@ function defaultWriterClosedPromiseResolve(writer: WritableStreamDefaultWriter<a
 }
 
 function defaultWriterReadyPromiseInitialize(writer: WritableStreamDefaultWriter<any>) {
-  writer._readyPromise = new Promise((resolve, reject) => {
+  writer._readyPromise = newPromise((resolve, reject) => {
     writer._readyPromise_resolve = resolve;
     writer._readyPromise_reject = reject;
   });

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -7,6 +7,7 @@ import {
   newPromise,
   promiseRejectedWith,
   promiseResolvedWith,
+  setPromiseIsHandledToTrue,
   typeIsObject,
   ValidateAndNormalizeHighWaterMark
 } from './helpers';
@@ -14,7 +15,6 @@ import { rethrowAssertionErrorRejection } from './utils';
 import { DequeueValue, EnqueueValueWithSize, PeekQueueValue, QueuePair, ResetQueue } from './queue-with-sizes';
 import { QueuingStrategy, QueuingStrategySizeCallback } from './queuing-strategy';
 import { SimpleQueue } from './simple-queue';
-import { noop } from '../utils';
 
 const AbortSteps = Symbol('[[AbortSteps]]');
 const ErrorSteps = Symbol('[[ErrorSteps]]');
@@ -1110,7 +1110,7 @@ function defaultWriterClosedPromiseReject(writer: WritableStreamDefaultWriter<an
   assert(writer._closedPromise_reject !== undefined);
   assert(writer._closedPromiseState === 'pending');
 
-  writer._closedPromise.catch(noop);
+  setPromiseIsHandledToTrue(writer._closedPromise);
   writer._closedPromise_reject!(reason);
   writer._closedPromise_resolve = undefined;
   writer._closedPromise_reject = undefined;
@@ -1158,7 +1158,7 @@ function defaultWriterReadyPromiseReject(writer: WritableStreamDefaultWriter<any
   assert(writer._readyPromise_resolve !== undefined);
   assert(writer._readyPromise_reject !== undefined);
 
-  writer._readyPromise.catch(noop);
+  setPromiseIsHandledToTrue(writer._readyPromise);
   writer._readyPromise_reject!(reason);
   writer._readyPromise_resolve = undefined;
   writer._readyPromise_reject = undefined;


### PR DESCRIPTION
This aligns the implementation with [spec version `ae5e0cb` of 23 August 2019](https://streams.spec.whatwg.org/commit-snapshots/ae5e0cb41e9f72cdd97f3a6d47bc674c1f4049d1/).

Comparison: https://github.com/whatwg/streams/compare/e4d3b1a826e34d27a7cb5485a1cc4b078608c9ec...ae5e0cb41e9f72cdd97f3a6d47bc674c1f4049d1