### PR TITLE
Accept polyfilled abort signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## Unreleased
 
 * 👓 Align with [spec version `ae5e0cb`](https://github.com/whatwg/streams/tree/ae5e0cb41e9f72cdd97f3a6d47bc674c1f4049d1/) ([#33](https://github.com/MattiasBuelens/web-streams-polyfill/pull/33))
+* 💅 Accept polyfilled `AbortSignal`s. ([#36](https://github.com/MattiasBuelens/web-streams-polyfill/pull/36))
 
 ## v2.0.4 (2019-08-01)
 

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -4,6 +4,16 @@
 
 ```ts
 
+// @public
+export interface AbortSignal {
+    // (undocumented)
+    readonly aborted: boolean;
+    // (undocumented)
+    addEventListener(type: 'abort', listener: () => void): void;
+    // (undocumented)
+    removeEventListener(type: 'abort', listener: () => void): void;
+}
+
 // @public (undocumented)
 export class ByteLengthQueuingStrategy implements QueuingStrategy<ArrayBufferView> {
     constructor({ highWaterMark }: {

--- a/src/lib/abort-signal.ts
+++ b/src/lib/abort-signal.ts
@@ -1,0 +1,16 @@
+/// <reference lib="dom" />
+
+export function isAbortSignal(value: any): value is AbortSignal {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  // Use the brand check to distinguish a real AbortSignal from a fake one.
+  const aborted = Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'aborted')!.get!;
+  try {
+    aborted.call(value);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/src/lib/abort-signal.ts
+++ b/src/lib/abort-signal.ts
@@ -1,16 +1,28 @@
-/// <reference lib="dom" />
+/**
+ * A signal object that allows you to communicate with a request and abort it if required
+ * via its associated `AbortController` object.
+ *
+ * @remarks
+ *   This interface is compatible with the `AbortSignal` interface defined in TypeScript's DOM types.
+ *   It is redefined here, so it can be polyfilled without a DOM, for example with
+ *   {@link https://www.npmjs.com/package/abortcontroller-polyfill | abortcontroller-polyfill} in a Node environment.
+ */
+export interface AbortSignal {
+  readonly aborted: boolean;
 
-export function isAbortSignal(value: any): value is AbortSignal {
+  addEventListener(type: 'abort', listener: () => void): void;
+
+  removeEventListener(type: 'abort', listener: () => void): void;
+}
+
+export function isAbortSignal(value: unknown): value is AbortSignal {
   if (typeof value !== 'object' || value === null) {
     return false;
   }
-
-  // Use the brand check to distinguish a real AbortSignal from a fake one.
-  const aborted = Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'aborted')!.get!;
   try {
-    aborted.call(value);
-    return true;
-  } catch (e) {
+    return typeof (value as AbortSignal).aborted === 'boolean';
+  } catch {
+    // AbortSignal.prototype.aborted throws if its brand check fails
     return false;
   }
 }

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -1,5 +1,3 @@
-/// <reference lib="dom" />
-
 import assert from '../stub/assert';
 import {
   createArrayFromList,
@@ -59,7 +57,7 @@ import {
   UnderlyingSource
 } from './readable-stream/underlying-source';
 import { noop } from '../utils';
-import { isAbortSignal } from './abort-signal';
+import { AbortSignal, isAbortSignal } from './abort-signal';
 
 export type ReadableByteStream = ReadableStream<Uint8Array>;
 

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -59,6 +59,7 @@ import {
   UnderlyingSource
 } from './readable-stream/underlying-source';
 import { noop } from '../utils';
+import { isAbortSignal } from './abort-signal';
 
 export type ReadableByteStream = ReadableStream<Uint8Array>;
 
@@ -438,21 +439,6 @@ export {
 };
 
 // Helper functions for the ReadableStream.
-
-export function isAbortSignal(value: any): value is AbortSignal {
-  if (typeof value !== 'object' || value === null) {
-    return false;
-  }
-
-  // Use the brand check to distinguish a real AbortSignal from a fake one.
-  const aborted = Object.getOwnPropertyDescriptor(AbortSignal.prototype, 'aborted')!.get!;
-  try {
-    aborted.call(value);
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
 
 function streamBrandCheckException(name: string): TypeError {
   return new TypeError(`ReadableStream.prototype.${name} can only be used on a ReadableStream`);

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -1,5 +1,3 @@
-/// <reference lib="dom" />
-
 import { IsReadableStream, IsReadableStreamLocked, ReadableStream, ReadableStreamCancel } from '../readable-stream';
 import { AcquireReadableStreamDefaultReader, ReadableStreamDefaultReaderRead } from './default-reader';
 import { ReadableStreamReaderGenericRelease } from './generic-reader';
@@ -25,7 +23,7 @@ import {
   uponRejection
 } from '../helpers';
 import { noop } from '../../utils';
-import { isAbortSignal } from '../abort-signal';
+import { AbortSignal, isAbortSignal } from '../abort-signal';
 
 export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
                                         dest: WritableStream<T>,

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -1,10 +1,6 @@
-import {
-  isAbortSignal,
-  IsReadableStream,
-  IsReadableStreamLocked,
-  ReadableStream,
-  ReadableStreamCancel
-} from '../readable-stream';
+/// <reference lib="dom" />
+
+import { IsReadableStream, IsReadableStreamLocked, ReadableStream, ReadableStreamCancel } from '../readable-stream';
 import { AcquireReadableStreamDefaultReader, ReadableStreamDefaultReaderRead } from './default-reader';
 import { ReadableStreamReaderGenericRelease } from './generic-reader';
 import {
@@ -29,6 +25,7 @@ import {
   uponRejection
 } from '../helpers';
 import { noop } from '../../utils';
+import { isAbortSignal } from '../abort-signal';
 
 export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
                                         dest: WritableStream<T>,

--- a/src/ponyfill.ts
+++ b/src/ponyfill.ts
@@ -21,6 +21,7 @@ import { QueuingStrategy } from './lib/queuing-strategy';
 import ByteLengthQueuingStrategy from './lib/byte-length-queuing-strategy';
 import CountQueuingStrategy from './lib/count-queuing-strategy';
 import { Transformer, TransformStream, TransformStreamDefaultControllerType } from './lib/transform-stream';
+import { AbortSignal } from './lib/abort-signal';
 
 export {
   ReadableStream,
@@ -46,5 +47,7 @@ export {
 
   TransformStream,
   Transformer,
-  TransformStreamDefaultControllerType as TransformStreamDefaultController
+  TransformStreamDefaultControllerType as TransformStreamDefaultController,
+
+  AbortSignal
 };

--- a/test/types/readable-stream.ts
+++ b/test/types/readable-stream.ts
@@ -108,6 +108,8 @@ const asyncIteratorReturnResult: Promise<IteratorResult<any>> = asyncIterator.re
   }
 })();
 
+const abortSignal: polyfill.AbortSignal = new AbortController().signal;
+
 // Compatibility with stream types from DOM
 const domUnderlyingSource: UnderlyingSource<string> = underlyingSource;
 const domUnderlyingByteSource: UnderlyingByteSource = underlyingByteSource;


### PR DESCRIPTION
Currently, the polyfill performs a brand check using the global `AbortSignal.prototype.aborted` ([source](https://github.com/MattiasBuelens/web-streams-polyfill/blob/5fd383471b619f01f1c570c82fc8d58b36efd402/src/lib/readable-stream.ts#L447-L454)). This makes it difficult to use the polyfill in a non-DOM environment where there is no global `AbortSignal`, and where `AbortController` and `AbortSignal` themselves need to be polyfilled.

This PR loosens the check, allowing any object with a boolean `aborted` property to be accepted as a valid `AbortSignal`. This is a small deviation from the specification, but makes the polyfill usable in more environments (e.g. Node).

In the future, if the polyfill is able to use the native streams implementation (#20), we must ensure that any polyfilled `AbortSignal` is first converted to a native `AbortSignal` before calling the native `pipeTo`/`pipeThrough` implementation.