### PR TITLE
Add DOMException polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * 👓 Align with [spec version `ae5e0cb`](https://github.com/whatwg/streams/tree/ae5e0cb41e9f72cdd97f3a6d47bc674c1f4049d1/) ([#33](https://github.com/MattiasBuelens/web-streams-polyfill/pull/33))
 * 💅 Accept polyfilled `AbortSignal`s. ([#36](https://github.com/MattiasBuelens/web-streams-polyfill/pull/36))
+* 💅 Polyfill `DOMException` if necessary. ([#37](https://github.com/MattiasBuelens/web-streams-polyfill/pull/37))
 
 ## v2.0.4 (2019-08-01)
 

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -36,6 +36,16 @@ export class CountQueuingStrategy implements QueuingStrategy<any> {
     size(): 1;
 }
 
+// Warning: (ae-forgotten-export) The symbol "DOMExceptionClass" needs to be exported by the entry point polyfill.d.ts
+// 
+// @public (undocumented)
+export type DOMException = DOMExceptionClass;
+
+// Warning: (ae-forgotten-export) The symbol "DOMExceptionConstructor" needs to be exported by the entry point polyfill.d.ts
+// 
+// @public (undocumented)
+export const DOMException: DOMExceptionConstructor;
+
 // @public (undocumented)
 export interface PipeOptions {
     // (undocumented)

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,21 +46,6 @@
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
           "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
           "dev": true
-        },
-        "resolve": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.5"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
         }
       }
     },
@@ -73,6 +58,14 @@
         "@microsoft/node-core-library": "3.13.0",
         "@microsoft/tsdoc": "0.12.10",
         "@types/node": "8.5.8"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+          "dev": true
+        }
       }
     },
     "@microsoft/node-core-library": {
@@ -91,6 +84,12 @@
         "z-schema": "~3.18.3"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+          "dev": true
+        },
         "colors": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
@@ -111,6 +110,12 @@
         "colors": "~1.2.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
+          "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+          "dev": true
+        },
         "colors": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
@@ -165,9 +170,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.8.tgz",
-      "integrity": "sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==",
+      "version": "12.7.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
+      "integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==",
       "dev": true
     },
     "@types/z-schema": {
@@ -187,17 +192,6 @@
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^2.0.1",
         "tsutils": "^3.7.0"
-      },
-      "dependencies": {
-        "tsutils": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.1.tgz",
-          "integrity": "sha512-kiuZzD1uUA5DxGj/uxbde+ymp6VVdAxdzOIlAFbYKrPyla8/uiJ9JLBm1QsPhOm4Muj0/+cWEDP99yoCUcSl6Q==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        }
       }
     },
     "@typescript-eslint/experimental-utils": {
@@ -683,13 +677,6 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
         }
       }
     },
@@ -752,16 +739,6 @@
           "requires": {
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
-          }
-        },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
           }
         },
         "semver": {
@@ -1301,6 +1278,16 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -1934,6 +1921,15 @@
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
+    "resolve": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.5"
+      }
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -1970,12 +1966,6 @@
         "acorn": "^6.2.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "12.6.8",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
-          "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
-          "dev": true
-        },
         "acorn": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
@@ -1993,26 +1983,6 @@
         "estree-walker": "^0.6.1",
         "magic-string": "^0.25.3",
         "rollup-pluginutils": "^2.8.1"
-      },
-      "dependencies": {
-        "magic-string": {
-          "version": "0.25.3",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.3.tgz",
-          "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.4"
-          }
-        },
-        "rollup-pluginutils": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
-          "integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
-          "dev": true,
-          "requires": {
-            "estree-walker": "^0.6.1"
-          }
-        }
       }
     },
     "rollup-plugin-replace": {
@@ -2023,32 +1993,6 @@
       "requires": {
         "magic-string": "^0.25.2",
         "rollup-pluginutils": "^2.6.0"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-          "dev": true
-        },
-        "magic-string": {
-          "version": "0.25.3",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.3.tgz",
-          "integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
-          "dev": true,
-          "requires": {
-            "sourcemap-codec": "^1.4.4"
-          }
-        },
-        "rollup-pluginutils": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
-          "integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
-          "dev": true,
-          "requires": {
-            "estree-walker": "^0.6.1"
-          }
-        }
       }
     },
     "rollup-plugin-strip": {
@@ -2073,17 +2017,6 @@
         "rollup-pluginutils": "^2.8.1",
         "serialize-javascript": "^1.7.0",
         "terser": "^4.1.0"
-      },
-      "dependencies": {
-        "rollup-pluginutils": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
-          "integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
-          "dev": true,
-          "requires": {
-            "estree-walker": "^0.6.1"
-          }
-        }
       }
     },
     "rollup-plugin-typescript2": {
@@ -2098,12 +2031,6 @@
         "tslib": "1.10.0"
       },
       "dependencies": {
-        "estree-walker": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-          "dev": true
-        },
         "fs-extra": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -2128,15 +2055,6 @@
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
-          }
-        },
-        "rollup-pluginutils": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz",
-          "integrity": "sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==",
-          "dev": true,
-          "requires": {
-            "estree-walker": "^0.6.1"
           }
         }
       }
@@ -2239,6 +2157,12 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
     "source-map-support": {
       "version": "0.5.12",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
@@ -2247,14 +2171,6 @@
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "sourcemap-codec": {
@@ -2429,12 +2345,6 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
           "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
         }
       }
     },
@@ -2492,6 +2402,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
+    },
+    "tsutils": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.1.tgz",
+      "integrity": "sha512-kiuZzD1uUA5DxGj/uxbde+ymp6VVdAxdzOIlAFbYKrPyla8/uiJ9JLBm1QsPhOm4Muj0/+cWEDP99yoCUcSl6Q==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -2686,7 +2605,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -2697,7 +2616,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "homepage": "https://github.com/MattiasBuelens/web-streams-polyfill#readme",
   "devDependencies": {
     "@microsoft/api-extractor": "^7.3.4",
+    "@types/node": "^12.7.11",
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
     "eslint": "^6.1.0",

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -24,6 +24,7 @@ import {
 } from '../helpers';
 import { noop } from '../../utils';
 import { AbortSignal, isAbortSignal } from '../abort-signal';
+import { DOMException } from '../../stub/dom-exception';
 
 export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
                                         dest: WritableStream<T>,

--- a/src/ponyfill.ts
+++ b/src/ponyfill.ts
@@ -22,6 +22,7 @@ import ByteLengthQueuingStrategy from './lib/byte-length-queuing-strategy';
 import CountQueuingStrategy from './lib/count-queuing-strategy';
 import { Transformer, TransformStream, TransformStreamDefaultControllerType } from './lib/transform-stream';
 import { AbortSignal } from './lib/abort-signal';
+import { DOMException } from './stub/dom-exception';
 
 export {
   ReadableStream,
@@ -49,5 +50,6 @@ export {
   Transformer,
   TransformStreamDefaultControllerType as TransformStreamDefaultController,
 
-  AbortSignal
+  AbortSignal,
+  DOMException
 };

--- a/src/stub/dom-exception.ts
+++ b/src/stub/dom-exception.ts
@@ -1,0 +1,42 @@
+/// <reference types="node" />
+import { NativeDOMException } from './native';
+
+declare class DOMExceptionClass extends Error {
+  constructor(message?: string, name?: string);
+
+  name: string;
+  message: string;
+}
+
+type DOMException = DOMExceptionClass;
+type DOMExceptionConstructor = typeof DOMExceptionClass;
+
+function isDOMExceptionConstructor(ctor: unknown): ctor is DOMExceptionConstructor {
+  if (!(typeof ctor === 'function' || typeof ctor === 'object')) {
+    return false;
+  }
+  try {
+    new (ctor as DOMExceptionConstructor)();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function createDOMExceptionPolyfill(): DOMExceptionConstructor {
+  const ctor = function DOMException(this: DOMException, message?: string, name?: string) {
+    this.message = message || '';
+    this.name = name || 'Error';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  } as any;
+  ctor.prototype = Object.create(Error.prototype);
+  Object.defineProperty(ctor.prototype, 'constructor', { value: ctor, writable: true, configurable: true });
+  return ctor;
+}
+
+const DOMException: DOMExceptionConstructor =
+  isDOMExceptionConstructor(NativeDOMException) ? NativeDOMException : createDOMExceptionPolyfill();
+
+export { DOMException };

--- a/src/stub/native.ts
+++ b/src/stub/native.ts
@@ -1,0 +1,2 @@
+/// <reference lib="dom" />
+export let NativeDOMException: typeof DOMException | undefined = typeof DOMException !== 'undefined' ? DOMException : undefined;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -7,6 +7,7 @@
       "es5",
       "es2015.promise"
     ],
+    "types": [],
     "strict": true,
     "stripInternal": true,
     "importHelpers": true,


### PR DESCRIPTION
[As noted earlier](https://github.com/MattiasBuelens/web-streams-polyfill/pull/36#issuecomment-539007093), we need to polyfill `DOMException` in order to support non-DOM environments such as Node. We also need it on Internet Explorer 11, where `DOMException` is not constructable from user code.

This PR does just that, enabling the streams polyfill to run without a browser.

In the future, we should add tests to verify that Node is still supported.