### PR TITLE
Use esnext.asynciterable for backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 🐛 Fix type definitions to be compatible with TypeScript 3.3 and lower. ([#39](https://github.com/MattiasBuelens/web-streams-polyfill/issues/39), [#40](https://github.com/MattiasBuelens/web-streams-polyfill/pull/40))
+
 ## v2.0.5 (2019-10-08)
 
 * 👓 Align with [spec version `ae5e0cb`](https://github.com/whatwg/streams/tree/ae5e0cb41e9f72cdd97f3a6d47bc674c1f4049d1/) ([#33](https://github.com/MattiasBuelens/web-streams-polyfill/pull/33))

--- a/src/lib/readable-stream/async-iterator.ts
+++ b/src/lib/readable-stream/async-iterator.ts
@@ -1,4 +1,4 @@
-/// <reference lib="es2018.asynciterable" />
+/// <reference lib="esnext.asynciterable" />
 
 import { ReadableStream } from '../readable-stream';
 import {

--- a/src/target/es2018/stub/async-iterator-prototype.ts
+++ b/src/target/es2018/stub/async-iterator-prototype.ts
@@ -1,4 +1,4 @@
-/// <reference lib="es2018.asynciterable" />
+/// <reference lib="esnext.asynciterable" />
 
 export const AsyncIteratorPrototype: AsyncIterable<any> | undefined =
   Object.getPrototypeOf(Object.getPrototypeOf(async function* (): AsyncIterableIterator<any> {}).prototype);

--- a/src/target/es5/stub/async-iterator-prototype.ts
+++ b/src/target/es5/stub/async-iterator-prototype.ts
@@ -1,4 +1,4 @@
-/// <reference lib="es2018.asynciterable" />
+/// <reference lib="esnext.asynciterable" />
 
 export let AsyncIteratorPrototype: AsyncIterable<any> | undefined;
 


### PR DESCRIPTION
Older TypeScript versions do not have `es2018.asynciterable` yet, but newer versions support both `es2018.asynciterable` and `esnext.asynciterable`. For compatibility, use the old name.

Fixes #39