### PR TITLE
More precise ReadResult type

### DIFF
--- a/src/lib/readable-stream/generic-reader.ts
+++ b/src/lib/readable-stream/generic-reader.ts
@@ -2,12 +2,16 @@ import assert from '../../stub/assert';
 import { ReadableStream, ReadableStreamCancel, ReadableStreamReader } from '../readable-stream';
 import { newPromise, setPromiseIsHandledToTrue } from '../helpers';
 
-export type ReadResult<T> = {
-  done: false;
-  value: T;
-} | {
+export type ReadResult<T> = ReadResultDoneResult<T> | ReadResultValueResult<T>;
+
+interface ReadResultDoneResult<T> {
   done: true;
   value?: T;
+}
+
+interface ReadResultValueResult<T> {
+  done: false;
+  value: T;
 }
 
 export function ReadableStreamCreateReadResult<T>(value: T | undefined,


### PR DESCRIPTION
This update creates a more precise `ReadResult` type, such that if the `ReadResult` is done, then the `value` of the `ReadResult` can be `undefined`. Otherwise, if the `ReadResult` is not done, then the `value` of the `ReadResult` is the generic type `T`. 

This follows the spec more closely: https://streams.spec.whatwg.org/#default-reader-read