### PR TITLE
Support importing as ESM in Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,33 @@
   "main": "dist/polyfill",
   "browser": "dist/polyfill.min.js",
   "module": "dist/polyfill.mjs",
+  "type": "commonjs",
+  "exports": {
+    ".": {
+      "import": "./dist/polyfill.mjs",
+      "require": "./dist/polyfill.js"
+    },
+    "./es6": {
+      "import": "./dist/polyfill.es6.mjs",
+      "require": "./dist/polyfill.es6.js"
+    },
+    "./es2018": {
+      "import": "./dist/polyfill.es2018.mjs",
+      "require": "./dist/polyfill.es2018.js"
+    },
+    "./ponyfill": {
+      "import": "./dist/ponyfill.mjs",
+      "require": "./dist/ponyfill.js"
+    },
+    "./ponyfill/es6": {
+      "import": "./dist/ponyfill.es6.mjs",
+      "require": "./dist/ponyfill.es6.js"
+    },
+    "./ponyfill/es2018": {
+      "import": "./dist/ponyfill.es2018.mjs",
+      "require": "./dist/ponyfill.es2018.js"
+    }
+  },
   "types": "dist/types/polyfill.d.ts",
   "typesVersions": {
     ">=3.6": {


### PR DESCRIPTION
This uses [conditional exports](https://nodejs.org/api/esm.html#esm_conditional_exports) to define the CommonJS and ES module paths for each variant. This enables modern Node versions to load the `.mjs` files, instead of the CommonJS `.js` builds.

[As explained in the documentation](https://nodejs.org/api/esm.html#esm_package_entry_points), this will prevent consumers from using anything that is not defined by `exports`, so they will no longer be to do e.g. `require("web-streams-polyfill/dist/polyfill.js")`. **This is likely a breaking change.**

Moreover, consumers may already be using `import streams from "web-streams-polyfill"` with modern Node, which would give them [the CommonJS module as a default export](https://nodejs.org/api/esm.html#esm_import_statements). **This will also break**, since the default export will be replaced by named exports. Consumers will need to change their code to either `import { ReadableStream } ...` or `import * as streams ...` instead.

To do:
- [ ] Add tests for loading the different variants as CommonJS or ES modules.