### PR TITLE
Simplify boolean comparisons

### DIFF
--- a/src/lib/abstract-ops/miscellaneous.ts
+++ b/src/lib/abstract-ops/miscellaneous.ts
@@ -1,7 +1,7 @@
 import NumberIsNaN from '../../stub/number-isnan';
 
 export function IsFiniteNonNegativeNumber(v: number): boolean {
-  if (IsNonNegativeNumber(v) === false) {
+  if (!IsNonNegativeNumber(v)) {
     return false;
   }
 

--- a/src/lib/byte-length-queuing-strategy.ts
+++ b/src/lib/byte-length-queuing-strategy.ts
@@ -18,14 +18,14 @@ export default class ByteLengthQueuingStrategy implements QueuingStrategy<ArrayB
   }
 
   get highWaterMark(): number {
-    if (IsByteLengthQueuingStrategy(this) === false) {
+    if (!IsByteLengthQueuingStrategy(this)) {
       throw byteLengthBrandCheckException('highWaterMark');
     }
     return this._byteLengthQueuingStrategyHighWaterMark;
   }
 
   get size(): (chunk: ArrayBufferView) => number {
-    if (IsByteLengthQueuingStrategy(this) === false) {
+    if (!IsByteLengthQueuingStrategy(this)) {
       throw byteLengthBrandCheckException('size');
     }
     return byteLengthSizeFunction;

--- a/src/lib/count-queuing-strategy.ts
+++ b/src/lib/count-queuing-strategy.ts
@@ -18,14 +18,14 @@ export default class CountQueuingStrategy implements QueuingStrategy<any> {
   }
 
   get highWaterMark(): number {
-    if (IsCountQueuingStrategy(this) === false) {
+    if (!IsCountQueuingStrategy(this)) {
       throw countBrandCheckException('highWaterMark');
     }
     return this._countQueuingStrategyHighWaterMark;
   }
 
   get size(): (chunk: any) => 1 {
-    if (IsCountQueuingStrategy(this) === false) {
+    if (!IsCountQueuingStrategy(this)) {
       throw countBrandCheckException('size');
     }
     return countSizeFunction;

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -119,7 +119,7 @@ export class ReadableStream<R = any> {
   }
 
   get locked(): boolean {
-    if (IsReadableStream(this) === false) {
+    if (!IsReadableStream(this)) {
       throw streamBrandCheckException('locked');
     }
 
@@ -127,7 +127,7 @@ export class ReadableStream<R = any> {
   }
 
   cancel(reason: any = undefined): Promise<void> {
-    if (IsReadableStream(this) === false) {
+    if (!IsReadableStream(this)) {
       return promiseRejectedWith(streamBrandCheckException('cancel'));
     }
 
@@ -143,7 +143,7 @@ export class ReadableStream<R = any> {
   getReader(
     rawOptions: ReadableStreamGetReaderOptions | null | undefined = undefined
   ): ReadableStreamDefaultReader<R> | ReadableStreamBYOBReader {
-    if (IsReadableStream(this) === false) {
+    if (!IsReadableStream(this)) {
       throw streamBrandCheckException('getReader');
     }
 
@@ -160,7 +160,7 @@ export class ReadableStream<R = any> {
   pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: PipeOptions): ReadableStream<T>;
   pipeThrough<T>(rawTransform: ReadableWritablePair<T, R> | null | undefined,
                  rawOptions: PipeOptions | null | undefined = {}): ReadableStream<T> {
-    if (IsReadableStream(this) === false) {
+    if (!IsReadableStream(this)) {
       throw streamBrandCheckException('pipeThrough');
     }
     assertRequiredArgument(rawTransform, 1, 'pipeThrough');
@@ -187,7 +187,7 @@ export class ReadableStream<R = any> {
   pipeTo(destination: WritableStream<R>, options?: PipeOptions): Promise<void>;
   pipeTo(destination: WritableStream<R> | null | undefined,
          rawOptions: PipeOptions | null | undefined = {}): Promise<void> {
-    if (IsReadableStream(this) === false) {
+    if (!IsReadableStream(this)) {
       return promiseRejectedWith(streamBrandCheckException('pipeTo'));
     }
 
@@ -224,7 +224,7 @@ export class ReadableStream<R = any> {
   }
 
   tee(): [ReadableStream<R>, ReadableStream<R>] {
-    if (IsReadableStream(this) === false) {
+    if (!IsReadableStream(this)) {
       throw streamBrandCheckException('tee');
     }
 
@@ -234,7 +234,7 @@ export class ReadableStream<R = any> {
 
   values(options?: ReadableStreamIteratorOptions): ReadableStreamAsyncIterator<R>;
   values(rawOptions: ReadableStreamIteratorOptions | null | undefined = undefined): ReadableStreamAsyncIterator<R> {
-    if (IsReadableStream(this) === false) {
+    if (!IsReadableStream(this)) {
       throw streamBrandCheckException('values');
     }
 

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -131,7 +131,7 @@ export class ReadableStream<R = any> {
       return promiseRejectedWith(streamBrandCheckException('cancel'));
     }
 
-    if (IsReadableStreamLocked(this) === true) {
+    if (IsReadableStreamLocked(this)) {
       return promiseRejectedWith(new TypeError('Cannot cancel a stream that already has a reader'));
     }
 
@@ -168,10 +168,10 @@ export class ReadableStream<R = any> {
     const transform = convertReadableWritablePair(rawTransform, 'First parameter');
     const options = convertPipeOptions(rawOptions, 'Second parameter');
 
-    if (IsReadableStreamLocked(this) === true) {
+    if (IsReadableStreamLocked(this)) {
       throw new TypeError('ReadableStream.prototype.pipeThrough cannot be used on a locked ReadableStream');
     }
-    if (IsWritableStreamLocked(transform.writable) === true) {
+    if (IsWritableStreamLocked(transform.writable)) {
       throw new TypeError('ReadableStream.prototype.pipeThrough cannot be used on a locked WritableStream');
     }
 
@@ -207,12 +207,12 @@ export class ReadableStream<R = any> {
       return promiseRejectedWith(e);
     }
 
-    if (IsReadableStreamLocked(this) === true) {
+    if (IsReadableStreamLocked(this)) {
       return promiseRejectedWith(
         new TypeError('ReadableStream.prototype.pipeTo cannot be used on a locked ReadableStream')
       );
     }
-    if (IsWritableStreamLocked(destination) === true) {
+    if (IsWritableStreamLocked(destination)) {
       return promiseRejectedWith(
         new TypeError('ReadableStream.prototype.pipeTo cannot be used on a locked WritableStream')
       );
@@ -289,7 +289,7 @@ export function CreateReadableStream<R>(startAlgorithm: () => void | PromiseLike
                                         cancelAlgorithm: (reason: any) => Promise<void>,
                                         highWaterMark = 1,
                                         sizeAlgorithm: QueuingStrategySizeCallback<R> = () => 1): ReadableStream<R> {
-  assert(IsNonNegativeNumber(highWaterMark) === true);
+  assert(IsNonNegativeNumber(highWaterMark));
 
   const stream: ReadableStream<R> = Object.create(ReadableStream.prototype);
   InitializeReadableStream(stream);
@@ -308,9 +308,9 @@ export function CreateReadableByteStream(startAlgorithm: () => void | PromiseLik
                                          cancelAlgorithm: (reason: any) => Promise<void>,
                                          highWaterMark = 0,
                                          autoAllocateChunkSize: number | undefined = undefined): ReadableStream<Uint8Array> {
-  assert(IsNonNegativeNumber(highWaterMark) === true);
+  assert(IsNonNegativeNumber(highWaterMark));
   if (autoAllocateChunkSize !== undefined) {
-    assert(NumberIsInteger(autoAllocateChunkSize) === true);
+    assert(NumberIsInteger(autoAllocateChunkSize));
     assert(autoAllocateChunkSize > 0);
   }
 
@@ -345,13 +345,13 @@ export function IsReadableStream(x: unknown): x is ReadableStream {
 }
 
 export function IsReadableStreamDisturbed(stream: ReadableStream): boolean {
-  assert(IsReadableStream(stream) === true);
+  assert(IsReadableStream(stream));
 
   return stream._disturbed;
 }
 
 export function IsReadableStreamLocked(stream: ReadableStream): boolean {
-  assert(IsReadableStream(stream) === true);
+  assert(IsReadableStream(stream));
 
   if (stream._reader === undefined) {
     return false;
@@ -400,7 +400,7 @@ export function ReadableStreamClose<R>(stream: ReadableStream<R>): void {
 }
 
 export function ReadableStreamError<R>(stream: ReadableStream<R>, e: any): void {
-  assert(IsReadableStream(stream) === true);
+  assert(IsReadableStream(stream));
   assert(stream._state === 'readable');
 
   stream._state = 'errored';

--- a/src/lib/readable-stream/async-iterator.ts
+++ b/src/lib/readable-stream/async-iterator.ts
@@ -111,14 +111,14 @@ declare class ReadableStreamAsyncIteratorInstance<R> implements ReadableStreamAs
 
 const ReadableStreamAsyncIteratorPrototype: ReadableStreamAsyncIteratorInstance<any> = {
   next(this: ReadableStreamAsyncIteratorInstance<any>): Promise<ReadResult<any>> {
-    if (IsReadableStreamAsyncIterator(this) === false) {
+    if (!IsReadableStreamAsyncIterator(this)) {
       return promiseRejectedWith(streamAsyncIteratorBrandCheckException('next'));
     }
     return this._asyncIteratorImpl.next();
   },
 
   return(this: ReadableStreamAsyncIteratorInstance<any>, value: any): Promise<ReadResult<any>> {
-    if (IsReadableStreamAsyncIterator(this) === false) {
+    if (!IsReadableStreamAsyncIterator(this)) {
       return promiseRejectedWith(streamAsyncIteratorBrandCheckException('return'));
     }
     return this._asyncIteratorImpl.return(value);

--- a/src/lib/readable-stream/byob-reader.ts
+++ b/src/lib/readable-stream/byob-reader.ts
@@ -104,7 +104,7 @@ export class ReadableStreamBYOBReader {
       throw new TypeError('This stream has already been locked for exclusive reading by another reader');
     }
 
-    if (IsReadableByteStreamController(stream._readableStreamController) === false) {
+    if (!IsReadableByteStreamController(stream._readableStreamController)) {
       throw new TypeError('Cannot construct a ReadableStreamBYOBReader for a stream not constructed with a byte ' +
         'source');
     }

--- a/src/lib/readable-stream/byob-reader.ts
+++ b/src/lib/readable-stream/byob-reader.ts
@@ -31,7 +31,7 @@ export function AcquireReadableStreamBYOBReader(stream: ReadableStream<Uint8Arra
 // ReadableStream API exposed for controllers.
 
 export function ReadableStreamAddReadIntoRequest<T extends ArrayBufferView>(stream: ReadableByteStream): Promise<ReadResult<T>> {
-  assert(IsReadableStreamBYOBReader(stream._reader) === true);
+  assert(IsReadableStreamBYOBReader(stream._reader));
   assert(stream._state === 'readable' || stream._state === 'closed');
 
   const promise = newPromise<ReadResult<T>>((resolve, reject) => {

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -40,7 +40,7 @@ export class ReadableStreamBYOBRequest {
   }
 
   get view(): ArrayBufferView | null {
-    if (IsReadableStreamBYOBRequest(this) === false) {
+    if (!IsReadableStreamBYOBRequest(this)) {
       throw byobRequestBrandCheckException('view');
     }
 
@@ -49,7 +49,7 @@ export class ReadableStreamBYOBRequest {
 
   respond(bytesWritten: number): void;
   respond(bytesWritten: number | undefined): void {
-    if (IsReadableStreamBYOBRequest(this) === false) {
+    if (!IsReadableStreamBYOBRequest(this)) {
       throw byobRequestBrandCheckException('respond');
     }
     assertRequiredArgument(bytesWritten, 1, 'respond');
@@ -71,7 +71,7 @@ export class ReadableStreamBYOBRequest {
 
   respondWithNewView(view: ArrayBufferView): void;
   respondWithNewView(view: ArrayBufferView | undefined): void {
-    if (IsReadableStreamBYOBRequest(this) === false) {
+    if (!IsReadableStreamBYOBRequest(this)) {
       throw byobRequestBrandCheckException('respondWithNewView');
     }
     assertRequiredArgument(view, 1, 'respondWithNewView');
@@ -176,7 +176,7 @@ export class ReadableByteStreamController {
   }
 
   get byobRequest(): ReadableStreamBYOBRequest | null {
-    if (IsReadableByteStreamController(this) === false) {
+    if (!IsReadableByteStreamController(this)) {
       throw byteStreamControllerBrandCheckException('byobRequest');
     }
 
@@ -195,7 +195,7 @@ export class ReadableByteStreamController {
   }
 
   get desiredSize(): number | null {
-    if (IsReadableByteStreamController(this) === false) {
+    if (!IsReadableByteStreamController(this)) {
       throw byteStreamControllerBrandCheckException('desiredSize');
     }
 
@@ -203,7 +203,7 @@ export class ReadableByteStreamController {
   }
 
   close(): void {
-    if (IsReadableByteStreamController(this) === false) {
+    if (!IsReadableByteStreamController(this)) {
       throw byteStreamControllerBrandCheckException('close');
     }
 
@@ -221,7 +221,7 @@ export class ReadableByteStreamController {
 
   enqueue(chunk: ArrayBufferView): void;
   enqueue(chunk: ArrayBufferView | undefined): void {
-    if (IsReadableByteStreamController(this) === false) {
+    if (!IsReadableByteStreamController(this)) {
       throw byteStreamControllerBrandCheckException('enqueue');
     }
 
@@ -249,7 +249,7 @@ export class ReadableByteStreamController {
   }
 
   error(e: any = undefined): void {
-    if (IsReadableByteStreamController(this) === false) {
+    if (!IsReadableByteStreamController(this)) {
       throw byteStreamControllerBrandCheckException('error');
     }
 
@@ -365,7 +365,7 @@ function IsReadableStreamBYOBRequest(x: any): x is ReadableStreamBYOBRequest {
 
 function ReadableByteStreamControllerCallPullIfNeeded(controller: ReadableByteStreamController): void {
   const shouldPull = ReadableByteStreamControllerShouldCallPull(controller);
-  if (shouldPull === false) {
+  if (!shouldPull) {
     return;
   }
 
@@ -374,7 +374,7 @@ function ReadableByteStreamControllerCallPullIfNeeded(controller: ReadableByteSt
     return;
   }
 
-  assert(controller._pullAgain === false);
+  assert(!controller._pullAgain);
 
   controller._pulling = true;
 
@@ -480,7 +480,7 @@ function ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller:
     totalBytesToCopyRemaining -= bytesToCopy;
   }
 
-  if (ready === false) {
+  if (!ready) {
     assert(controller._queueTotalSize === 0);
     assert(pullIntoDescriptor.bytesFilled > 0);
     assert(pullIntoDescriptor.bytesFilled < pullIntoDescriptor.elementSize);
@@ -520,7 +520,7 @@ function ReadableByteStreamControllerInvalidateBYOBRequest(controller: ReadableB
 }
 
 function ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller: ReadableByteStreamController) {
-  assert(controller._closeRequested === false);
+  assert(!controller._closeRequested);
 
   while (controller._pendingPullIntos.length > 0) {
     if (controller._queueTotalSize === 0) {
@@ -685,7 +685,7 @@ function ReadableByteStreamControllerShouldCallPull(controller: ReadableByteStre
     return false;
   }
 
-  if (controller._started === false) {
+  if (!controller._started) {
     return false;
   }
 
@@ -766,7 +766,7 @@ function ReadableByteStreamControllerEnqueue(controller: ReadableByteStreamContr
     ReadableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
     ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller);
   } else {
-    assert(IsReadableStreamLocked(stream) === false);
+    assert(!IsReadableStreamLocked(stream));
     ReadableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
   }
 
@@ -803,7 +803,7 @@ function ReadableByteStreamControllerGetDesiredSize(controller: ReadableByteStre
 
 function ReadableByteStreamControllerRespond(controller: ReadableByteStreamController, bytesWritten: number) {
   bytesWritten = Number(bytesWritten);
-  if (IsFiniteNonNegativeNumber(bytesWritten) === false) {
+  if (!IsFiniteNonNegativeNumber(bytesWritten)) {
     throw new RangeError('bytesWritten must be a finite');
   }
 
@@ -874,8 +874,8 @@ export function SetUpReadableByteStreamController(stream: ReadableByteStream,
     () => {
       controller._started = true;
 
-      assert(controller._pulling === false);
-      assert(controller._pullAgain === false);
+      assert(!controller._pulling);
+      assert(!controller._pullAgain);
 
       ReadableByteStreamControllerCallPullIfNeeded(controller);
     },
@@ -919,7 +919,7 @@ function SetUpReadableStreamBYOBRequest(request: ReadableStreamBYOBRequest,
   assert(IsReadableByteStreamController(controller));
   assert(typeof view === 'object');
   assert(ArrayBuffer.isView(view));
-  assert(IsDetachedBuffer(view.buffer) === false);
+  assert(!IsDetachedBuffer(view.buffer));
   request._associatedReadableByteStreamController = controller;
   request._view = view;
 }

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -59,7 +59,7 @@ export class ReadableStreamBYOBRequest {
       throw new TypeError('This BYOB request has been invalidated');
     }
 
-    if (IsDetachedBuffer(this._view!.buffer) === true) {
+    if (IsDetachedBuffer(this._view!.buffer)) {
       throw new TypeError(`The BYOB request's buffer has been detached and so cannot be used as a response`);
     }
 
@@ -207,7 +207,7 @@ export class ReadableByteStreamController {
       throw byteStreamControllerBrandCheckException('close');
     }
 
-    if (this._closeRequested === true) {
+    if (this._closeRequested) {
       throw new TypeError('The stream has already been closed; do not close it again!');
     }
 
@@ -236,7 +236,7 @@ export class ReadableByteStreamController {
       throw new TypeError(`chunk's buffer must have non-zero byteLength`);
     }
 
-    if (this._closeRequested === true) {
+    if (this._closeRequested) {
       throw new TypeError('stream is closed or draining');
     }
 
@@ -273,7 +273,7 @@ export class ReadableByteStreamController {
   /** @internal */
   [PullSteps](): Promise<ReadResult<ArrayBufferView>> {
     const stream = this._controlledReadableByteStream;
-    assert(ReadableStreamHasDefaultReader(stream) === true);
+    assert(ReadableStreamHasDefaultReader(stream));
 
     if (this._queueTotalSize > 0) {
       assert(ReadableStreamGetNumReadRequests(stream) === 0);
@@ -369,7 +369,7 @@ function ReadableByteStreamControllerCallPullIfNeeded(controller: ReadableByteSt
     return;
   }
 
-  if (controller._pulling === true) {
+  if (controller._pulling) {
     controller._pullAgain = true;
     return;
   }
@@ -385,7 +385,7 @@ function ReadableByteStreamControllerCallPullIfNeeded(controller: ReadableByteSt
     () => {
       controller._pulling = false;
 
-      if (controller._pullAgain === true) {
+      if (controller._pullAgain) {
         controller._pullAgain = false;
         ReadableByteStreamControllerCallPullIfNeeded(controller);
       }
@@ -501,7 +501,7 @@ function ReadableByteStreamControllerFillHeadPullIntoDescriptor(controller: Read
 function ReadableByteStreamControllerHandleQueueDrain(controller: ReadableByteStreamController) {
   assert(controller._controlledReadableByteStream._state === 'readable');
 
-  if (controller._queueTotalSize === 0 && controller._closeRequested === true) {
+  if (controller._queueTotalSize === 0 && controller._closeRequested) {
     ReadableByteStreamControllerClearAlgorithms(controller);
     ReadableStreamClose(controller._controlledReadableByteStream);
   } else {
@@ -529,7 +529,7 @@ function ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(contro
 
     const pullIntoDescriptor = controller._pendingPullIntos.peek();
 
-    if (ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller, pullIntoDescriptor) === true) {
+    if (ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller, pullIntoDescriptor)) {
       ReadableByteStreamControllerShiftPendingPullInto(controller);
 
       ReadableByteStreamControllerCommitPullIntoDescriptor(
@@ -578,7 +578,7 @@ export function ReadableByteStreamControllerPullInto<T extends ArrayBufferView>(
   }
 
   if (controller._queueTotalSize > 0) {
-    if (ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller, pullIntoDescriptor) === true) {
+    if (ReadableByteStreamControllerFillPullIntoDescriptorFromQueue(controller, pullIntoDescriptor)) {
       const filledView = ReadableByteStreamControllerConvertPullIntoDescriptor<T>(pullIntoDescriptor);
 
       ReadableByteStreamControllerHandleQueueDrain(controller);
@@ -586,7 +586,7 @@ export function ReadableByteStreamControllerPullInto<T extends ArrayBufferView>(
       return promiseResolvedWith(ReadableStreamCreateReadResult(filledView, false, stream._reader!._forAuthorCode));
     }
 
-    if (controller._closeRequested === true) {
+    if (controller._closeRequested) {
       const e = new TypeError('Insufficient bytes to fill elements in the given buffer');
       ReadableByteStreamControllerError(controller, e);
 
@@ -610,7 +610,7 @@ function ReadableByteStreamControllerRespondInClosedState(controller: ReadableBy
   assert(firstDescriptor.bytesFilled === 0);
 
   const stream = controller._controlledReadableByteStream;
-  if (ReadableStreamHasBYOBReader(stream) === true) {
+  if (ReadableStreamHasBYOBReader(stream)) {
     while (ReadableStreamGetNumReadIntoRequests(stream) > 0) {
       const pullIntoDescriptor = ReadableByteStreamControllerShiftPendingPullInto(controller);
       ReadableByteStreamControllerCommitPullIntoDescriptor(stream, pullIntoDescriptor);
@@ -681,7 +681,7 @@ function ReadableByteStreamControllerShouldCallPull(controller: ReadableByteStre
     return false;
   }
 
-  if (controller._closeRequested === true) {
+  if (controller._closeRequested) {
     return false;
   }
 
@@ -689,11 +689,11 @@ function ReadableByteStreamControllerShouldCallPull(controller: ReadableByteStre
     return false;
   }
 
-  if (ReadableStreamHasDefaultReader(stream) === true && ReadableStreamGetNumReadRequests(stream) > 0) {
+  if (ReadableStreamHasDefaultReader(stream) && ReadableStreamGetNumReadRequests(stream) > 0) {
     return true;
   }
 
-  if (ReadableStreamHasBYOBReader(stream) === true && ReadableStreamGetNumReadIntoRequests(stream) > 0) {
+  if (ReadableStreamHasBYOBReader(stream) && ReadableStreamGetNumReadIntoRequests(stream) > 0) {
     return true;
   }
 
@@ -716,7 +716,7 @@ function ReadableByteStreamControllerClearAlgorithms(controller: ReadableByteStr
 function ReadableByteStreamControllerClose(controller: ReadableByteStreamController) {
   const stream = controller._controlledReadableByteStream;
 
-  if (controller._closeRequested === true || stream._state !== 'readable') {
+  if (controller._closeRequested || stream._state !== 'readable') {
     return;
   }
 
@@ -743,7 +743,7 @@ function ReadableByteStreamControllerClose(controller: ReadableByteStreamControl
 function ReadableByteStreamControllerEnqueue(controller: ReadableByteStreamController, chunk: ArrayBufferView) {
   const stream = controller._controlledReadableByteStream;
 
-  if (controller._closeRequested === true || stream._state !== 'readable') {
+  if (controller._closeRequested || stream._state !== 'readable') {
     return;
   }
 
@@ -752,7 +752,7 @@ function ReadableByteStreamControllerEnqueue(controller: ReadableByteStreamContr
   const byteLength = chunk.byteLength;
   const transferredBuffer = TransferArrayBuffer(buffer);
 
-  if (ReadableStreamHasDefaultReader(stream) === true) {
+  if (ReadableStreamHasDefaultReader(stream)) {
     if (ReadableStreamGetNumReadRequests(stream) === 0) {
       ReadableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
     } else {
@@ -761,7 +761,7 @@ function ReadableByteStreamControllerEnqueue(controller: ReadableByteStreamContr
       const transferredView = new Uint8Array(transferredBuffer, byteOffset, byteLength);
       ReadableStreamFulfillReadRequest(stream, transferredView, false);
     }
-  } else if (ReadableStreamHasBYOBReader(stream) === true) {
+  } else if (ReadableStreamHasBYOBReader(stream)) {
     // TODO: Ideally in this branch detaching should happen only if the buffer is not consumed fully.
     ReadableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
     ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(controller);
@@ -839,7 +839,7 @@ export function SetUpReadableByteStreamController(stream: ReadableByteStream,
                                                   autoAllocateChunkSize: number | undefined) {
   assert(stream._readableStreamController === undefined);
   if (autoAllocateChunkSize !== undefined) {
-    assert(NumberIsInteger(autoAllocateChunkSize) === true);
+    assert(NumberIsInteger(autoAllocateChunkSize));
     assert(autoAllocateChunkSize > 0);
   }
 
@@ -916,9 +916,9 @@ export function SetUpReadableByteStreamControllerFromUnderlyingSource(
 function SetUpReadableStreamBYOBRequest(request: ReadableStreamBYOBRequest,
                                         controller: ReadableByteStreamController,
                                         view: ArrayBufferView) {
-  assert(IsReadableByteStreamController(controller) === true);
+  assert(IsReadableByteStreamController(controller));
   assert(typeof view === 'object');
-  assert(ArrayBuffer.isView(view) === true);
+  assert(ArrayBuffer.isView(view));
   assert(IsDetachedBuffer(view.buffer) === false);
   request._associatedReadableByteStreamController = controller;
   request._view = view;

--- a/src/lib/readable-stream/default-controller.ts
+++ b/src/lib/readable-stream/default-controller.ts
@@ -43,7 +43,7 @@ export class ReadableStreamDefaultController<R> {
   }
 
   get desiredSize(): number | null {
-    if (IsReadableStreamDefaultController(this) === false) {
+    if (!IsReadableStreamDefaultController(this)) {
       throw defaultControllerBrandCheckException('desiredSize');
     }
 
@@ -51,11 +51,11 @@ export class ReadableStreamDefaultController<R> {
   }
 
   close(): void {
-    if (IsReadableStreamDefaultController(this) === false) {
+    if (!IsReadableStreamDefaultController(this)) {
       throw defaultControllerBrandCheckException('close');
     }
 
-    if (ReadableStreamDefaultControllerCanCloseOrEnqueue(this) === false) {
+    if (!ReadableStreamDefaultControllerCanCloseOrEnqueue(this)) {
       throw new TypeError('The stream is not in a state that permits close');
     }
 
@@ -64,11 +64,11 @@ export class ReadableStreamDefaultController<R> {
 
   enqueue(chunk: R): void;
   enqueue(chunk: R = undefined!): void {
-    if (IsReadableStreamDefaultController(this) === false) {
+    if (!IsReadableStreamDefaultController(this)) {
       throw defaultControllerBrandCheckException('enqueue');
     }
 
-    if (ReadableStreamDefaultControllerCanCloseOrEnqueue(this) === false) {
+    if (!ReadableStreamDefaultControllerCanCloseOrEnqueue(this)) {
       throw new TypeError('The stream is not in a state that permits enqueue');
     }
 
@@ -76,7 +76,7 @@ export class ReadableStreamDefaultController<R> {
   }
 
   error(e: any = undefined): void {
-    if (IsReadableStreamDefaultController(this) === false) {
+    if (!IsReadableStreamDefaultController(this)) {
       throw defaultControllerBrandCheckException('error');
     }
 
@@ -143,7 +143,7 @@ function IsReadableStreamDefaultController<R>(x: any): x is ReadableStreamDefaul
 
 function ReadableStreamDefaultControllerCallPullIfNeeded(controller: ReadableStreamDefaultController<any>): void {
   const shouldPull = ReadableStreamDefaultControllerShouldCallPull(controller);
-  if (shouldPull === false) {
+  if (!shouldPull) {
     return;
   }
 
@@ -152,7 +152,7 @@ function ReadableStreamDefaultControllerCallPullIfNeeded(controller: ReadableStr
     return;
   }
 
-  assert(controller._pullAgain === false);
+  assert(!controller._pullAgain);
 
   controller._pulling = true;
 
@@ -176,11 +176,11 @@ function ReadableStreamDefaultControllerCallPullIfNeeded(controller: ReadableStr
 function ReadableStreamDefaultControllerShouldCallPull(controller: ReadableStreamDefaultController<any>): boolean {
   const stream = controller._controlledReadableStream;
 
-  if (ReadableStreamDefaultControllerCanCloseOrEnqueue(controller) === false) {
+  if (!ReadableStreamDefaultControllerCanCloseOrEnqueue(controller)) {
     return false;
   }
 
-  if (controller._started === false) {
+  if (!controller._started) {
     return false;
   }
 
@@ -206,7 +206,7 @@ function ReadableStreamDefaultControllerClearAlgorithms(controller: ReadableStre
 // A client of ReadableStreamDefaultController may use these functions directly to bypass state check.
 
 export function ReadableStreamDefaultControllerClose(controller: ReadableStreamDefaultController<any>) {
-  if (ReadableStreamDefaultControllerCanCloseOrEnqueue(controller) === false) {
+  if (!ReadableStreamDefaultControllerCanCloseOrEnqueue(controller)) {
     return;
   }
 
@@ -221,7 +221,7 @@ export function ReadableStreamDefaultControllerClose(controller: ReadableStreamD
 }
 
 export function ReadableStreamDefaultControllerEnqueue<R>(controller: ReadableStreamDefaultController<R>, chunk: R): void {
-  if (ReadableStreamDefaultControllerCanCloseOrEnqueue(controller) === false) {
+  if (!ReadableStreamDefaultControllerCanCloseOrEnqueue(controller)) {
     return;
   }
 
@@ -288,7 +288,7 @@ export function ReadableStreamDefaultControllerHasBackpressure(controller: Reada
 export function ReadableStreamDefaultControllerCanCloseOrEnqueue(controller: ReadableStreamDefaultController<any>): boolean {
   const state = controller._controlledReadableStream._state;
 
-  if (controller._closeRequested === false && state === 'readable') {
+  if (!controller._closeRequested && state === 'readable') {
     return true;
   }
 
@@ -329,8 +329,8 @@ export function SetUpReadableStreamDefaultController<R>(stream: ReadableStream<R
     () => {
       controller._started = true;
 
-      assert(controller._pulling === false);
-      assert(controller._pullAgain === false);
+      assert(!controller._pulling);
+      assert(!controller._pullAgain);
 
       ReadableStreamDefaultControllerCallPullIfNeeded(controller);
     },

--- a/src/lib/readable-stream/default-controller.ts
+++ b/src/lib/readable-stream/default-controller.ts
@@ -98,7 +98,7 @@ export class ReadableStreamDefaultController<R> {
     if (this._queue.length > 0) {
       const chunk = DequeueValue(this);
 
-      if (this._closeRequested === true && this._queue.length === 0) {
+      if (this._closeRequested && this._queue.length === 0) {
         ReadableStreamDefaultControllerClearAlgorithms(this);
         ReadableStreamClose(stream);
       } else {
@@ -147,7 +147,7 @@ function ReadableStreamDefaultControllerCallPullIfNeeded(controller: ReadableStr
     return;
   }
 
-  if (controller._pulling === true) {
+  if (controller._pulling) {
     controller._pullAgain = true;
     return;
   }
@@ -162,7 +162,7 @@ function ReadableStreamDefaultControllerCallPullIfNeeded(controller: ReadableStr
     () => {
       controller._pulling = false;
 
-      if (controller._pullAgain === true) {
+      if (controller._pullAgain) {
         controller._pullAgain = false;
         ReadableStreamDefaultControllerCallPullIfNeeded(controller);
       }
@@ -184,7 +184,7 @@ function ReadableStreamDefaultControllerShouldCallPull(controller: ReadableStrea
     return false;
   }
 
-  if (IsReadableStreamLocked(stream) === true && ReadableStreamGetNumReadRequests(stream) > 0) {
+  if (IsReadableStreamLocked(stream) && ReadableStreamGetNumReadRequests(stream) > 0) {
     return true;
   }
 
@@ -227,7 +227,7 @@ export function ReadableStreamDefaultControllerEnqueue<R>(controller: ReadableSt
 
   const stream = controller._controlledReadableStream;
 
-  if (IsReadableStreamLocked(stream) === true && ReadableStreamGetNumReadRequests(stream) > 0) {
+  if (IsReadableStreamLocked(stream) && ReadableStreamGetNumReadRequests(stream) > 0) {
     ReadableStreamFulfillReadRequest(stream, chunk, false);
   } else {
     let chunkSize;
@@ -278,7 +278,7 @@ export function ReadableStreamDefaultControllerGetDesiredSize(controller: Readab
 
 // This is used in the implementation of TransformStream.
 export function ReadableStreamDefaultControllerHasBackpressure(controller: ReadableStreamDefaultController<any>): boolean {
-  if (ReadableStreamDefaultControllerShouldCallPull(controller) === true) {
+  if (ReadableStreamDefaultControllerShouldCallPull(controller)) {
     return false;
   }
 

--- a/src/lib/readable-stream/default-reader.ts
+++ b/src/lib/readable-stream/default-reader.ts
@@ -27,7 +27,7 @@ export function AcquireReadableStreamDefaultReader<R>(stream: ReadableStream,
 // ReadableStream API exposed for controllers.
 
 export function ReadableStreamAddReadRequest<R>(stream: ReadableStream<R>): Promise<ReadResult<R>> {
-  assert(IsReadableStreamDefaultReader(stream._reader) === true);
+  assert(IsReadableStreamDefaultReader(stream._reader));
   assert(stream._state === 'readable');
 
   const promise = newPromise<ReadResult<R>>((resolve, reject) => {
@@ -94,7 +94,7 @@ export class ReadableStreamDefaultReader<R> {
     assertRequiredArgument(stream, 1, 'ReadableStreamDefaultReader');
     assertReadableStream(stream, 'First parameter');
 
-    if (IsReadableStreamLocked(stream) === true) {
+    if (IsReadableStreamLocked(stream)) {
       throw new TypeError('This stream has already been locked for exclusive reading by another reader');
     }
 

--- a/src/lib/readable-stream/generic-reader.ts
+++ b/src/lib/readable-stream/generic-reader.ts
@@ -14,7 +14,7 @@ export function ReadableStreamCreateReadResult<T>(value: T | undefined,
                                                   done: boolean,
                                                   forAuthorCode: boolean): ReadResult<T> {
   let prototype: object | null = null;
-  if (forAuthorCode === true) {
+  if (forAuthorCode) {
     prototype = Object.prototype;
   }
   assert(typeof done === 'boolean');

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -32,8 +32,8 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
                                         preventAbort: boolean,
                                         preventCancel: boolean,
                                         signal: AbortSignal | undefined): Promise<void> {
-  assert(IsReadableStream(source) === true);
-  assert(IsWritableStream(dest) === true);
+  assert(IsReadableStream(source));
+  assert(IsWritableStream(dest));
   assert(typeof preventClose === 'boolean');
   assert(typeof preventAbort === 'boolean');
   assert(typeof preventCancel === 'boolean');
@@ -76,7 +76,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
         shutdownWithAction(() => Promise.all(actions.map(action => action())), true, error);
       };
 
-      if (signal.aborted === true) {
+      if (signal.aborted) {
         abortAlgorithm();
         return;
       }
@@ -104,13 +104,13 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
     }
 
     function pipeStep(): Promise<boolean> {
-      if (shuttingDown === true) {
+      if (shuttingDown) {
         return promiseResolvedWith(true);
       }
 
       return PerformPromiseThen(writer._readyPromise, () => {
         return PerformPromiseThen(ReadableStreamDefaultReaderRead(reader), result => {
-          if (result.done === true) {
+          if (result.done) {
             return true;
           }
 
@@ -148,7 +148,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
     });
 
     // Closing must be propagated backward
-    if (WritableStreamCloseQueuedOrInFlight(dest) === true || dest._state === 'closed') {
+    if (WritableStreamCloseQueuedOrInFlight(dest) || dest._state === 'closed') {
       const destClosed = new TypeError('the destination writable stream closed before all data could be piped to it');
 
       if (preventCancel === false) {
@@ -189,7 +189,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
     }
 
     function shutdownWithAction(action: () => Promise<unknown>, originalIsError?: boolean, originalError?: any) {
-      if (shuttingDown === true) {
+      if (shuttingDown) {
         return;
       }
       shuttingDown = true;
@@ -210,7 +210,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
     }
 
     function shutdown(isError?: boolean, error?: any) {
-      if (shuttingDown === true) {
+      if (shuttingDown) {
         return;
       }
       shuttingDown = true;

--- a/src/lib/readable-stream/tee.ts
+++ b/src/lib/readable-stream/tee.ts
@@ -19,7 +19,7 @@ import { CreateArrayFromList } from '../abstract-ops/ecmascript';
 
 export function ReadableStreamTee<R>(stream: ReadableStream<R>,
                                      cloneForBranch2: boolean): [ReadableStream<R>, ReadableStream<R>] {
-  assert(IsReadableStream(stream) === true);
+  assert(IsReadableStream(stream));
   assert(typeof cloneForBranch2 === 'boolean');
 
   const reader = AcquireReadableStreamDefaultReader<R>(stream);
@@ -38,7 +38,7 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
   });
 
   function pullAlgorithm(): Promise<void> {
-    if (reading === true) {
+    if (reading) {
       return promiseResolvedWith(undefined);
     }
 
@@ -51,7 +51,7 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
       const done = result.done;
       assert(typeof done === 'boolean');
 
-      if (done === true) {
+      if (done) {
         if (canceled1 === false) {
           ReadableStreamDefaultControllerClose(branch1._readableStreamController as ReadableStreamDefaultController<R>);
         }
@@ -67,7 +67,7 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
 
       // There is no way to access the cloning code right now in the reference implementation.
       // If we add one then we'll need an implementation for serializable objects.
-      // if (canceled2 === false && cloneForBranch2 === true) {
+      // if (canceled2 === false && cloneForBranch2) {
       //   value2 = StructuredDeserialize(StructuredSerialize(value2));
       // }
 
@@ -94,7 +94,7 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
   function cancel1Algorithm(reason: any): Promise<void> {
     canceled1 = true;
     reason1 = reason;
-    if (canceled2 === true) {
+    if (canceled2) {
       const compositeReason = CreateArrayFromList([reason1, reason2]);
       const cancelResult = ReadableStreamCancel(stream, compositeReason);
       resolveCancelPromise(cancelResult);
@@ -105,7 +105,7 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
   function cancel2Algorithm(reason: any): Promise<void> {
     canceled2 = true;
     reason2 = reason;
-    if (canceled1 === true) {
+    if (canceled1) {
       const compositeReason = CreateArrayFromList([reason1, reason2]);
       const cancelResult = ReadableStreamCancel(stream, compositeReason);
       resolveCancelPromise(cancelResult);

--- a/src/lib/readable-stream/tee.ts
+++ b/src/lib/readable-stream/tee.ts
@@ -52,10 +52,10 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
       assert(typeof done === 'boolean');
 
       if (done) {
-        if (canceled1 === false) {
+        if (!canceled1) {
           ReadableStreamDefaultControllerClose(branch1._readableStreamController as ReadableStreamDefaultController<R>);
         }
-        if (canceled2 === false) {
+        if (!canceled2) {
           ReadableStreamDefaultControllerClose(branch2._readableStreamController as ReadableStreamDefaultController<R>);
         }
         return;
@@ -67,18 +67,18 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
 
       // There is no way to access the cloning code right now in the reference implementation.
       // If we add one then we'll need an implementation for serializable objects.
-      // if (canceled2 === false && cloneForBranch2) {
+      // if (!canceled2 && cloneForBranch2) {
       //   value2 = StructuredDeserialize(StructuredSerialize(value2));
       // }
 
-      if (canceled1 === false) {
+      if (!canceled1) {
         ReadableStreamDefaultControllerEnqueue(
           branch1._readableStreamController as ReadableStreamDefaultController<R>,
           value1
         );
       }
 
-      if (canceled2 === false) {
+      if (!canceled2) {
         ReadableStreamDefaultControllerEnqueue(
           branch2._readableStreamController as ReadableStreamDefaultController<R>,
           value2

--- a/src/lib/transform-stream.ts
+++ b/src/lib/transform-stream.ts
@@ -80,7 +80,7 @@ export class TransformStream<I = any, O = any> {
   }
 
   get readable(): ReadableStream<O> {
-    if (IsTransformStream(this) === false) {
+    if (!IsTransformStream(this)) {
       throw streamBrandCheckException('readable');
     }
 
@@ -88,7 +88,7 @@ export class TransformStream<I = any, O = any> {
   }
 
   get writable(): WritableStream<I> {
-    if (IsTransformStream(this) === false) {
+    if (!IsTransformStream(this)) {
       throw streamBrandCheckException('writable');
     }
 
@@ -248,7 +248,7 @@ export class TransformStreamDefaultController<O> {
   }
 
   get desiredSize(): number | null {
-    if (IsTransformStreamDefaultController(this) === false) {
+    if (!IsTransformStreamDefaultController(this)) {
       throw defaultControllerBrandCheckException('desiredSize');
     }
 
@@ -258,7 +258,7 @@ export class TransformStreamDefaultController<O> {
 
   enqueue(chunk: O): void;
   enqueue(chunk: O = undefined!): void {
-    if (IsTransformStreamDefaultController(this) === false) {
+    if (!IsTransformStreamDefaultController(this)) {
       throw defaultControllerBrandCheckException('enqueue');
     }
 
@@ -266,7 +266,7 @@ export class TransformStreamDefaultController<O> {
   }
 
   error(reason: any = undefined): void {
-    if (IsTransformStreamDefaultController(this) === false) {
+    if (!IsTransformStreamDefaultController(this)) {
       throw defaultControllerBrandCheckException('error');
     }
 
@@ -274,7 +274,7 @@ export class TransformStreamDefaultController<O> {
   }
 
   terminate(): void {
-    if (IsTransformStreamDefaultController(this) === false) {
+    if (!IsTransformStreamDefaultController(this)) {
       throw defaultControllerBrandCheckException('terminate');
     }
 
@@ -358,7 +358,7 @@ function TransformStreamDefaultControllerClearAlgorithms(controller: TransformSt
 function TransformStreamDefaultControllerEnqueue<O>(controller: TransformStreamDefaultController<O>, chunk: O) {
   const stream = controller._controlledTransformStream;
   const readableController = stream._readable._readableStreamController as ReadableStreamDefaultController<O>;
-  if (ReadableStreamDefaultControllerCanCloseOrEnqueue(readableController) === false) {
+  if (!ReadableStreamDefaultControllerCanCloseOrEnqueue(readableController)) {
     throw new TypeError('Readable side is not in a state that permits enqueue');
   }
 

--- a/src/lib/transform-stream.ts
+++ b/src/lib/transform-stream.ts
@@ -210,7 +210,7 @@ function TransformStreamError(stream: TransformStream, e: any) {
 function TransformStreamErrorWritableAndUnblockWrite(stream: TransformStream, e: any) {
   TransformStreamDefaultControllerClearAlgorithms(stream._transformStreamController);
   WritableStreamDefaultControllerErrorIfNeeded(stream._writable._writableStreamController, e);
-  if (stream._backpressure === true) {
+  if (stream._backpressure) {
     // Pretend that pull() was called to permit any pending write() calls to complete. TransformStreamSetBackpressure()
     // cannot be called from enqueue() or pull() once the ReadableStream is errored, so this will will be the final time
     // _backpressure is set.
@@ -313,7 +313,7 @@ function SetUpTransformStreamDefaultController<I, O>(stream: TransformStream<I, 
                                                      controller: TransformStreamDefaultController<O>,
                                                      transformAlgorithm: (chunk: I) => Promise<void>,
                                                      flushAlgorithm: () => Promise<void>) {
-  assert(IsTransformStream(stream) === true);
+  assert(IsTransformStream(stream));
   assert(stream._transformStreamController === undefined);
 
   controller._controlledTransformStream = stream;
@@ -376,7 +376,7 @@ function TransformStreamDefaultControllerEnqueue<O>(controller: TransformStreamD
 
   const backpressure = ReadableStreamDefaultControllerHasBackpressure(readableController);
   if (backpressure !== stream._backpressure) {
-    assert(backpressure === true);
+    assert(backpressure);
     TransformStreamSetBackpressure(stream, true);
   }
 }
@@ -411,7 +411,7 @@ function TransformStreamDefaultSinkWriteAlgorithm<I, O>(stream: TransformStream<
 
   const controller = stream._transformStreamController;
 
-  if (stream._backpressure === true) {
+  if (stream._backpressure) {
     const backpressureChangePromise = stream._backpressureChangePromise;
     assert(backpressureChangePromise !== undefined);
     return transformPromiseWith(backpressureChangePromise, () => {
@@ -449,7 +449,7 @@ function TransformStreamDefaultSinkCloseAlgorithm<I, O>(stream: TransformStream<
       throw readable._storedError;
     }
     const readableController = readable._readableStreamController as ReadableStreamDefaultController<O>;
-    if (ReadableStreamDefaultControllerCanCloseOrEnqueue(readableController) === true) {
+    if (ReadableStreamDefaultControllerCanCloseOrEnqueue(readableController)) {
       ReadableStreamDefaultControllerClose(readableController);
     }
   }, r => {
@@ -462,7 +462,7 @@ function TransformStreamDefaultSinkCloseAlgorithm<I, O>(stream: TransformStream<
 
 function TransformStreamDefaultSourcePullAlgorithm(stream: TransformStream): Promise<void> {
   // Invariant. Enforced by the promises returned by start() and pull().
-  assert(stream._backpressure === true);
+  assert(stream._backpressure);
 
   assert(stream._backpressureChangePromise !== undefined);
 

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -91,7 +91,7 @@ class WritableStream<W = any> {
   }
 
   get locked(): boolean {
-    if (IsWritableStream(this) === false) {
+    if (!IsWritableStream(this)) {
       throw streamBrandCheckException('locked');
     }
 
@@ -99,7 +99,7 @@ class WritableStream<W = any> {
   }
 
   abort(reason: any = undefined): Promise<void> {
-    if (IsWritableStream(this) === false) {
+    if (!IsWritableStream(this)) {
       return promiseRejectedWith(streamBrandCheckException('abort'));
     }
 
@@ -111,7 +111,7 @@ class WritableStream<W = any> {
   }
 
   close() {
-    if (IsWritableStream(this) === false) {
+    if (!IsWritableStream(this)) {
       return promiseRejectedWith(streamBrandCheckException('close'));
     }
 
@@ -127,7 +127,7 @@ class WritableStream<W = any> {
   }
 
   getWriter(): WritableStreamDefaultWriter<W> {
-    if (IsWritableStream(this) === false) {
+    if (!IsWritableStream(this)) {
       throw streamBrandCheckException('getWriter');
     }
 
@@ -275,7 +275,7 @@ function WritableStreamAbort(stream: WritableStream, reason: any): Promise<void>
   });
   stream._pendingAbortRequest!._promise = promise;
 
-  if (wasAlreadyErroring === false) {
+  if (!wasAlreadyErroring) {
     WritableStreamStartErroring(stream, reason);
   }
 
@@ -290,7 +290,7 @@ function WritableStreamClose(stream: WritableStream<any>): Promise<void> {
   }
 
   assert(state === 'writable' || state === 'erroring');
-  assert(WritableStreamCloseQueuedOrInFlight(stream) === false);
+  assert(!WritableStreamCloseQueuedOrInFlight(stream));
 
   const promise = newPromise<void>((resolve, reject) => {
     const closeRequest: CloseRequest = {
@@ -355,14 +355,14 @@ function WritableStreamStartErroring(stream: WritableStream, reason: any) {
     WritableStreamDefaultWriterEnsureReadyPromiseRejected(writer, reason);
   }
 
-  if (WritableStreamHasOperationMarkedInFlight(stream) === false && controller._started) {
+  if (!WritableStreamHasOperationMarkedInFlight(stream) && controller._started) {
     WritableStreamFinishErroring(stream);
   }
 }
 
 function WritableStreamFinishErroring(stream: WritableStream) {
   assert(stream._state === 'erroring');
-  assert(WritableStreamHasOperationMarkedInFlight(stream) === false);
+  assert(!WritableStreamHasOperationMarkedInFlight(stream));
   stream._state = 'errored';
   stream._writableStreamController[ErrorSteps]();
 
@@ -505,14 +505,14 @@ function WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream: WritableStrea
 
 function WritableStreamUpdateBackpressure(stream: WritableStream, backpressure: boolean) {
   assert(stream._state === 'writable');
-  assert(WritableStreamCloseQueuedOrInFlight(stream) === false);
+  assert(!WritableStreamCloseQueuedOrInFlight(stream));
 
   const writer = stream._writer;
   if (writer !== undefined && backpressure !== stream._backpressure) {
     if (backpressure) {
       defaultWriterReadyPromiseReset(writer);
     } else {
-      assert(backpressure === false);
+      assert(!backpressure);
 
       defaultWriterReadyPromiseResolve(writer);
     }
@@ -555,7 +555,7 @@ export class WritableStreamDefaultWriter<W> {
     const state = stream._state;
 
     if (state === 'writable') {
-      if (WritableStreamCloseQueuedOrInFlight(stream) === false && stream._backpressure) {
+      if (!WritableStreamCloseQueuedOrInFlight(stream) && stream._backpressure) {
         defaultWriterReadyPromiseInitialize(this);
       } else {
         defaultWriterReadyPromiseInitializeAsResolved(this);
@@ -578,7 +578,7 @@ export class WritableStreamDefaultWriter<W> {
   }
 
   get closed(): Promise<void> {
-    if (IsWritableStreamDefaultWriter(this) === false) {
+    if (!IsWritableStreamDefaultWriter(this)) {
       return promiseRejectedWith(defaultWriterBrandCheckException('closed'));
     }
 
@@ -586,7 +586,7 @@ export class WritableStreamDefaultWriter<W> {
   }
 
   get desiredSize(): number | null {
-    if (IsWritableStreamDefaultWriter(this) === false) {
+    if (!IsWritableStreamDefaultWriter(this)) {
       throw defaultWriterBrandCheckException('desiredSize');
     }
 
@@ -598,7 +598,7 @@ export class WritableStreamDefaultWriter<W> {
   }
 
   get ready(): Promise<void> {
-    if (IsWritableStreamDefaultWriter(this) === false) {
+    if (!IsWritableStreamDefaultWriter(this)) {
       return promiseRejectedWith(defaultWriterBrandCheckException('ready'));
     }
 
@@ -606,7 +606,7 @@ export class WritableStreamDefaultWriter<W> {
   }
 
   abort(reason: any = undefined): Promise<void> {
-    if (IsWritableStreamDefaultWriter(this) === false) {
+    if (!IsWritableStreamDefaultWriter(this)) {
       return promiseRejectedWith(defaultWriterBrandCheckException('abort'));
     }
 
@@ -618,7 +618,7 @@ export class WritableStreamDefaultWriter<W> {
   }
 
   close(): Promise<void> {
-    if (IsWritableStreamDefaultWriter(this) === false) {
+    if (!IsWritableStreamDefaultWriter(this)) {
       return promiseRejectedWith(defaultWriterBrandCheckException('close'));
     }
 
@@ -636,7 +636,7 @@ export class WritableStreamDefaultWriter<W> {
   }
 
   releaseLock(): void {
-    if (IsWritableStreamDefaultWriter(this) === false) {
+    if (!IsWritableStreamDefaultWriter(this)) {
       throw defaultWriterBrandCheckException('releaseLock');
     }
 
@@ -653,7 +653,7 @@ export class WritableStreamDefaultWriter<W> {
 
   write(chunk: W): Promise<void>;
   write(chunk: W = undefined!): Promise<void> {
-    if (IsWritableStreamDefaultWriter(this) === false) {
+    if (!IsWritableStreamDefaultWriter(this)) {
       return promiseRejectedWith(defaultWriterBrandCheckException('write'));
     }
 
@@ -845,7 +845,7 @@ export class WritableStreamDefaultController<W = any> {
   }
 
   error(e: any = undefined): void {
-    if (IsWritableStreamDefaultController(this) === false) {
+    if (!IsWritableStreamDefaultController(this)) {
       throw new TypeError(
         'WritableStreamDefaultController.prototype.error can only be used on a WritableStreamDefaultController');
     }
@@ -1015,7 +1015,7 @@ function WritableStreamDefaultControllerWrite<W>(controller: WritableStreamDefau
   }
 
   const stream = controller._controlledWritableStream;
-  if (WritableStreamCloseQueuedOrInFlight(stream) === false && stream._state === 'writable') {
+  if (!WritableStreamCloseQueuedOrInFlight(stream) && stream._state === 'writable') {
     const backpressure = WritableStreamDefaultControllerGetBackpressure(controller);
     WritableStreamUpdateBackpressure(stream, backpressure);
   }
@@ -1028,7 +1028,7 @@ function WritableStreamDefaultControllerWrite<W>(controller: WritableStreamDefau
 function WritableStreamDefaultControllerAdvanceQueueIfNeeded<W>(controller: WritableStreamDefaultController<W>) {
   const stream = controller._controlledWritableStream;
 
-  if (controller._started === false) {
+  if (!controller._started) {
     return;
   }
 
@@ -1098,7 +1098,7 @@ function WritableStreamDefaultControllerProcessWrite<W>(controller: WritableStre
 
       DequeueValue(controller);
 
-      if (WritableStreamCloseQueuedOrInFlight(stream) === false && state === 'writable') {
+      if (!WritableStreamCloseQueuedOrInFlight(stream) && state === 'writable') {
         const backpressure = WritableStreamDefaultControllerGetBackpressure(controller);
         WritableStreamUpdateBackpressure(stream, backpressure);
       }


### PR DESCRIPTION
The reference implementation uses a lot of `x === true` and `x === false`. This is quite verbose and doesn't minify well, so replace it with simpler `x` and `!x`.