### PR TITLE
Update to spec version of 20 July 2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ## Unreleased
 
-* 👓 Align with [spec version `caf3cea`](https://github.com/whatwg/streams/tree/caf3cea28134d8be2ec69b6a1105748a7c8d10b5/) ([#52](https://github.com/MattiasBuelens/web-streams-polyfill/pull/52), [#57](https://github.com/MattiasBuelens/web-streams-polyfill/pull/57))
+* 👓 Align with [spec version `62fe4c8`](https://github.com/whatwg/streams/tree/62fe4c8c0df34cec4ff28db9bfa69aec6c65e38d/) ([#52](https://github.com/MattiasBuelens/web-streams-polyfill/pull/52), [#57](https://github.com/MattiasBuelens/web-streams-polyfill/pull/57), [#59](https://github.com/MattiasBuelens/web-streams-polyfill/pull/59))
 
 ## v2.1.1 (2020-04-11)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `polyfill/es2018` and `ponyfill/es2018` variants work in any ES2018-compatib
 
 ### Compliance
 
-The polyfill implements [version `caf3cea` (11 Jun 2020)][spec-snapshot] of the streams specification.
+The polyfill implements [version `62fe4c8` (20 Jul 2020)][spec-snapshot] of the streams specification.
 
 The polyfill is tested against the same [web platform tests][wpt] that are used by browsers to test their native implementations.
 The polyfill aims to pass all tests, although it allows some exceptions for practical reasons:
@@ -99,11 +99,11 @@ Thanks to these people for their work on [the original polyfill][creatorrr-polyf
 [promise-support]: https://kangax.github.io/compat-table/es6/#test-Promise
 [promise-polyfill]: https://www.npmjs.com/package/promise-polyfill
 [rs-asynciterator]: https://streams.spec.whatwg.org/#rs-asynciterator
-[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/caf3cea28134d8be2ec69b6a1105748a7c8d10b5/
+[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/62fe4c8c0df34cec4ff28db9bfa69aec6c65e38d/
 [wpt]: https://github.com/web-platform-tests/wpt/tree/c5f9e701753a034f99dda16d4716c465bed73e18/streams
 [wpt-bad-buffers]: https://github.com/web-platform-tests/wpt/blob/c5f9e701753a034f99dda16d4716c465bed73e18/streams/readable-byte-streams/bad-buffers-and-views.any.js
 [proposal-arraybuffer-transfer]: https://github.com/domenic/proposal-arraybuffer-transfer
-[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/caf3cea28134d8be2ec69b6a1105748a7c8d10b5/reference-implementation/lib/abstract-ops/ecmascript.js#L16
+[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/62fe4c8c0df34cec4ff28db9bfa69aec6c65e38d/reference-implementation/lib/abstract-ops/ecmascript.js#L16
 [issue-3]: https://github.com/MattiasBuelens/web-streams-polyfill/issues/3
 [wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/c5f9e701753a034f99dda16d4716c465bed73e18/streams/readable-streams/async-iterator.any.js#L28
 [stub-async-iterator-prototype]: https://github.com/MattiasBuelens/web-streams-polyfill/blob/v2.0.0/src/target/es5/stub/async-iterator-prototype.ts

--- a/src/lib/helpers/miscellaneous.ts
+++ b/src/lib/helpers/miscellaneous.ts
@@ -1,20 +1,9 @@
-import { globals, noop } from '../../utils';
+import { noop } from '../../utils';
 import { AssertionError } from '../../stub/assert';
-import { PerformPromiseThen, promiseResolvedWith } from './webidl';
 
 export function typeIsObject(x: any): x is object {
   return (typeof x === 'object' && x !== null) || typeof x === 'function';
 }
-
-export const queueMicrotask: (fn: () => void) => void = (() => {
-  const globalQueueMicrotask = globals && globals.queueMicrotask;
-  if (typeof globalQueueMicrotask === 'function') {
-    return globalQueueMicrotask;
-  }
-
-  const resolvedPromise = promiseResolvedWith(undefined);
-  return (fn: () => void) => PerformPromiseThen(resolvedPromise, fn);
-})();
 
 export const rethrowAssertionErrorRejection: (e: any) => void =
   DEBUG ? e => {

--- a/src/lib/helpers/miscellaneous.ts
+++ b/src/lib/helpers/miscellaneous.ts
@@ -1,9 +1,20 @@
-import { noop } from '../../utils';
+import { globals, noop } from '../../utils';
 import { AssertionError } from '../../stub/assert';
+import { PerformPromiseThen, promiseResolvedWith } from './webidl';
 
 export function typeIsObject(x: any): x is object {
   return (typeof x === 'object' && x !== null) || typeof x === 'function';
 }
+
+export const queueMicrotask: (fn: () => void) => void = (() => {
+  const globalQueueMicrotask = globals && globals.queueMicrotask;
+  if (typeof globalQueueMicrotask === 'function') {
+    return globalQueueMicrotask;
+  }
+
+  const resolvedPromise = promiseResolvedWith(undefined);
+  return (fn: () => void) => PerformPromiseThen(resolvedPromise, fn);
+})();
 
 export const rethrowAssertionErrorRejection: (e: any) => void =
   DEBUG ? e => {

--- a/src/lib/helpers/webidl.ts
+++ b/src/lib/helpers/webidl.ts
@@ -1,3 +1,4 @@
+import { globals } from '../../utils';
 import { rethrowAssertionErrorRejection } from './miscellaneous';
 import assert from '../../stub/assert';
 
@@ -59,6 +60,16 @@ export function transformPromiseWith<T, TResult1 = T, TResult2 = never>(
 export function setPromiseIsHandledToTrue(promise: Promise<unknown>): void {
   PerformPromiseThen(promise, undefined, rethrowAssertionErrorRejection);
 }
+
+export const queueMicrotask: (fn: () => void) => void = (() => {
+  const globalQueueMicrotask = globals && globals.queueMicrotask;
+  if (typeof globalQueueMicrotask === 'function') {
+    return globalQueueMicrotask;
+  }
+
+  const resolvedPromise = promiseResolvedWith(undefined);
+  return (fn: () => void) => PerformPromiseThen(resolvedPromise, fn);
+})();
 
 export function reflectCall<T, A extends any[], R>(F: (this: T, ...args: A) => R, V: T, args: A): R {
   if (typeof F !== 'function') {

--- a/src/lib/readable-stream/async-iterator.ts
+++ b/src/lib/readable-stream/async-iterator.ts
@@ -15,8 +15,14 @@ import {
 } from './generic-reader';
 import assert from '../../stub/assert';
 import { AsyncIteratorPrototype } from '@@target/stub/async-iterator-prototype';
-import { queueMicrotask, typeIsObject } from '../helpers/miscellaneous';
-import { newPromise, promiseRejectedWith, promiseResolvedWith, transformPromiseWith } from '../helpers/webidl';
+import { typeIsObject } from '../helpers/miscellaneous';
+import {
+  newPromise,
+  promiseRejectedWith,
+  promiseResolvedWith,
+  queueMicrotask,
+  transformPromiseWith
+} from '../helpers/webidl';
 
 export interface ReadableStreamAsyncIterator<R> extends AsyncIterator<R> {
   next(): Promise<IteratorResult<R>>;

--- a/src/lib/readable-stream/async-iterator.ts
+++ b/src/lib/readable-stream/async-iterator.ts
@@ -86,15 +86,15 @@ export class ReadableStreamAsyncIteratorImpl<R> {
     if (reader._ownerReadableStream === undefined) {
       return promiseRejectedWith(readerLockException('finish iterating'));
     }
-    if (reader._readRequests.length > 0) {
-      return promiseRejectedWith(new TypeError(
-        'Tried to release a reader lock when that reader has pending read() calls un-settled'));
-    }
+
+    assert(reader._readRequests.length === 0);
+
     if (!this._preventCancel) {
       const result = ReadableStreamReaderGenericCancel(reader, value);
       ReadableStreamReaderGenericRelease(reader);
       return transformPromiseWith(result, () => ({ value, done: true }));
     }
+
     ReadableStreamReaderGenericRelease(reader);
     return promiseResolvedWith({ value, done: true });
   }

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -283,12 +283,7 @@ export class ReadableByteStreamController {
 
       ReadableByteStreamControllerHandleQueueDrain(this);
 
-      let view: ArrayBufferView;
-      try {
-        view = new Uint8Array(entry.buffer, entry.byteOffset, entry.byteLength);
-      } catch (viewE) {
-        return promiseRejectedWith(viewE);
-      }
+      const view = new Uint8Array(entry.buffer, entry.byteOffset, entry.byteLength);
 
       return promiseResolvedWith(ReadableStreamCreateReadResult(view, false, stream._reader!._forAuthorCode));
     }

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -129,7 +129,7 @@ interface DefaultPullIntoDescriptor {
   byteLength: number;
   bytesFilled: number;
   elementSize: number;
-  ctor: ArrayBufferViewConstructor<Uint8Array>;
+  viewConstructor: ArrayBufferViewConstructor<Uint8Array>;
   readerType: 'default';
 }
 
@@ -139,7 +139,7 @@ interface BYOBPullIntoDescriptor<T extends ArrayBufferView = ArrayBufferView> {
   byteLength: number;
   bytesFilled: number;
   elementSize: number;
-  ctor: ArrayBufferViewConstructor<T>;
+  viewConstructor: ArrayBufferViewConstructor<T>;
   readerType: 'byob';
 }
 
@@ -308,7 +308,7 @@ export class ReadableByteStreamController {
         byteLength: autoAllocateChunkSize,
         bytesFilled: 0,
         elementSize: 1,
-        ctor: Uint8Array,
+        viewConstructor: Uint8Array,
         readerType: 'default'
       };
 
@@ -427,7 +427,7 @@ function ReadableByteStreamControllerConvertPullIntoDescriptor<T extends ArrayBu
   assert(bytesFilled <= pullIntoDescriptor.byteLength);
   assert(bytesFilled % elementSize === 0);
 
-  return new pullIntoDescriptor.ctor(
+  return new pullIntoDescriptor.viewConstructor(
     pullIntoDescriptor.buffer, pullIntoDescriptor.byteOffset, bytesFilled / elementSize) as T;
 }
 
@@ -558,7 +558,7 @@ export function ReadableByteStreamControllerPullInto<T extends ArrayBufferView>(
     byteLength: view.byteLength,
     bytesFilled: 0,
     elementSize,
-    ctor,
+    viewConstructor: ctor,
     readerType: 'byob'
   };
 

--- a/src/lib/readable-stream/generic-reader.ts
+++ b/src/lib/readable-stream/generic-reader.ts
@@ -10,22 +10,7 @@ export type ReadResult<T> = {
   value: T | undefined;
 }
 
-export function ReadableStreamCreateReadResult<T>(value: T | undefined,
-                                                  done: boolean,
-                                                  forAuthorCode: boolean): ReadResult<T> {
-  let prototype: object | null = null;
-  if (forAuthorCode) {
-    prototype = Object.prototype;
-  }
-  assert(typeof done === 'boolean');
-  const obj: ReadResult<T> = Object.create(prototype);
-  obj.value = value!;
-  obj.done = done;
-  return obj;
-}
-
 export function ReadableStreamReaderGenericInitialize<R>(reader: ReadableStreamReader<R>, stream: ReadableStream<R>) {
-  reader._forAuthorCode = true;
   reader._ownerReadableStream = stream;
   stream._reader = reader;
 

--- a/src/lib/readable-stream/tee.ts
+++ b/src/lib/readable-stream/tee.ts
@@ -1,20 +1,14 @@
 import { CreateReadableStream, IsReadableStream, ReadableStream, ReadableStreamCancel } from '../readable-stream';
-import { AcquireReadableStreamDefaultReader, ReadableStreamDefaultReaderRead } from './default-reader';
+import { AcquireReadableStreamDefaultReader, ReadableStreamDefaultReaderRead, ReadRequest } from './default-reader';
 import assert from '../../stub/assert';
-import {
-  newPromise,
-  promiseResolvedWith,
-  setPromiseIsHandledToTrue,
-  transformPromiseWith,
-  uponRejection
-} from '../helpers/webidl';
+import { newPromise, promiseResolvedWith, uponRejection } from '../helpers/webidl';
 import {
   ReadableStreamDefaultController,
   ReadableStreamDefaultControllerClose,
   ReadableStreamDefaultControllerEnqueue,
   ReadableStreamDefaultControllerError
 } from './default-controller';
-import { typeIsObject } from '../helpers/miscellaneous';
+import { queueMicrotask } from '../helpers/miscellaneous';
 import { CreateArrayFromList } from '../abstract-ops/ecmascript';
 
 export function ReadableStreamTee<R>(stream: ReadableStream<R>,
@@ -44,49 +38,51 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
 
     reading = true;
 
-    const readPromise = transformPromiseWith(ReadableStreamDefaultReaderRead(reader), result => {
-      reading = false;
+    const readRequest: ReadRequest<R> = {
+      _chunkSteps: value => {
+        // This needs to be delayed a microtask because it takes at least a microtask to detect errors (using
+        // reader._closedPromise below), and we want errors in stream to error both branches immediately. We cannot let
+        // successful synchronously-available reads get ahead of asynchronously-available errors.
+        queueMicrotask(() => {
+          reading = false;
+          const value1 = value;
+          const value2 = value;
 
-      assert(typeIsObject(result));
-      const done = result.done;
-      assert(typeof done === 'boolean');
+          // There is no way to access the cloning code right now in the reference implementation.
+          // If we add one then we'll need an implementation for serializable objects.
+          // if (!canceled2 && cloneForBranch2) {
+          //   value2 = StructuredDeserialize(StructuredSerialize(value2));
+          // }
 
-      if (done) {
+          if (!canceled1) {
+            ReadableStreamDefaultControllerEnqueue(
+              branch1._readableStreamController as ReadableStreamDefaultController<R>,
+              value1
+            );
+          }
+
+          if (!canceled2) {
+            ReadableStreamDefaultControllerEnqueue(
+              branch2._readableStreamController as ReadableStreamDefaultController<R>,
+              value2
+            );
+          }
+        });
+      },
+      _closeSteps: () => {
+        reading = false;
         if (!canceled1) {
           ReadableStreamDefaultControllerClose(branch1._readableStreamController as ReadableStreamDefaultController<R>);
         }
         if (!canceled2) {
           ReadableStreamDefaultControllerClose(branch2._readableStreamController as ReadableStreamDefaultController<R>);
         }
-        return;
+      },
+      _errorSteps: () => {
+        reading = false;
       }
-
-      const value = result.value!;
-      const value1 = value;
-      const value2 = value;
-
-      // There is no way to access the cloning code right now in the reference implementation.
-      // If we add one then we'll need an implementation for serializable objects.
-      // if (!canceled2 && cloneForBranch2) {
-      //   value2 = StructuredDeserialize(StructuredSerialize(value2));
-      // }
-
-      if (!canceled1) {
-        ReadableStreamDefaultControllerEnqueue(
-          branch1._readableStreamController as ReadableStreamDefaultController<R>,
-          value1
-        );
-      }
-
-      if (!canceled2) {
-        ReadableStreamDefaultControllerEnqueue(
-          branch2._readableStreamController as ReadableStreamDefaultController<R>,
-          value2
-        );
-      }
-    });
-
-    setPromiseIsHandledToTrue(readPromise);
+    };
+    ReadableStreamDefaultReaderRead(reader, readRequest);
 
     return promiseResolvedWith(undefined);
   }

--- a/src/lib/readable-stream/tee.ts
+++ b/src/lib/readable-stream/tee.ts
@@ -1,14 +1,13 @@
 import { CreateReadableStream, IsReadableStream, ReadableStream, ReadableStreamCancel } from '../readable-stream';
 import { AcquireReadableStreamDefaultReader, ReadableStreamDefaultReaderRead, ReadRequest } from './default-reader';
 import assert from '../../stub/assert';
-import { newPromise, promiseResolvedWith, uponRejection } from '../helpers/webidl';
+import { newPromise, promiseResolvedWith, queueMicrotask, uponRejection } from '../helpers/webidl';
 import {
   ReadableStreamDefaultController,
   ReadableStreamDefaultControllerClose,
   ReadableStreamDefaultControllerEnqueue,
   ReadableStreamDefaultControllerError
 } from './default-controller';
-import { queueMicrotask } from '../helpers/miscellaneous';
 import { CreateArrayFromList } from '../abstract-ops/ecmascript';
 
 export function ReadableStreamTee<R>(stream: ReadableStream<R>,

--- a/src/lib/transform-stream.ts
+++ b/src/lib/transform-stream.ts
@@ -325,8 +325,6 @@ function SetUpTransformStreamDefaultController<I, O>(stream: TransformStream<I, 
 
 function SetUpTransformStreamDefaultControllerFromTransformer<I, O>(stream: TransformStream<I, O>,
                                                                     transformer: ValidatedTransformer<I, O>) {
-  assert(transformer !== undefined);
-
   const controller: TransformStreamDefaultController<O> = Object.create(TransformStreamDefaultController.prototype);
 
   let transformAlgorithm = (chunk: I): Promise<void> => {

--- a/src/lib/transform-stream.ts
+++ b/src/lib/transform-stream.ts
@@ -448,10 +448,7 @@ function TransformStreamDefaultSinkCloseAlgorithm<I, O>(stream: TransformStream<
     if (readable._state === 'errored') {
       throw readable._storedError;
     }
-    const readableController = readable._readableStreamController as ReadableStreamDefaultController<O>;
-    if (ReadableStreamDefaultControllerCanCloseOrEnqueue(readableController)) {
-      ReadableStreamDefaultControllerClose(readableController);
-    }
+    ReadableStreamDefaultControllerClose(readable._readableStreamController as ReadableStreamDefaultController<O>);
   }, r => {
     TransformStreamError(stream, r);
     throw readable._storedError;

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -946,8 +946,6 @@ function SetUpWritableStreamDefaultControllerFromUnderlyingSink<W>(stream: Writa
                                                                    underlyingSink: ValidatedUnderlyingSink<W>,
                                                                    highWaterMark: number,
                                                                    sizeAlgorithm: QueuingStrategySizeCallback<W>) {
-  assert(underlyingSink !== undefined);
-
   const controller = Object.create(WritableStreamDefaultController.prototype);
 
   let startAlgorithm: () => void | PromiseLike<void> = () => undefined;

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -814,11 +814,9 @@ function WritableStreamDefaultWriterWrite<W>(writer: WritableStreamDefaultWriter
   return promise;
 }
 
-interface WriteRecord<W> {
-  chunk: W;
-}
+const closeSentinel: unique symbol = {} as any;
 
-type QueueRecord<W> = WriteRecord<W> | 'close';
+type QueueRecord<W> = W | typeof closeSentinel;
 
 export class WritableStreamDefaultController<W = any> {
   /** @internal */
@@ -983,8 +981,8 @@ function WritableStreamDefaultControllerClearAlgorithms(controller: WritableStre
   controller._strategySizeAlgorithm = undefined!;
 }
 
-function WritableStreamDefaultControllerClose(controller: WritableStreamDefaultController<any>) {
-  EnqueueValueWithSize(controller, 'close', 0);
+function WritableStreamDefaultControllerClose<W>(controller: WritableStreamDefaultController<W>) {
+  EnqueueValueWithSize(controller, closeSentinel, 0);
   WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller);
 }
 
@@ -1005,10 +1003,8 @@ function WritableStreamDefaultControllerGetDesiredSize(controller: WritableStrea
 function WritableStreamDefaultControllerWrite<W>(controller: WritableStreamDefaultController<W>,
                                                  chunk: W,
                                                  chunkSize: number) {
-  const writeRecord = { chunk };
-
   try {
-    EnqueueValueWithSize(controller, writeRecord, chunkSize);
+    EnqueueValueWithSize(controller, chunk, chunkSize);
   } catch (enqueueE) {
     WritableStreamDefaultControllerErrorIfNeeded(controller, enqueueE);
     return;
@@ -1047,11 +1043,11 @@ function WritableStreamDefaultControllerAdvanceQueueIfNeeded<W>(controller: Writ
     return;
   }
 
-  const writeRecord = PeekQueueValue(controller);
-  if (writeRecord === 'close') {
+  const value = PeekQueueValue(controller);
+  if (value === closeSentinel) {
     WritableStreamDefaultControllerProcessClose(controller);
   } else {
-    WritableStreamDefaultControllerProcessWrite(controller, writeRecord.chunk);
+    WritableStreamDefaultControllerProcessWrite(controller, value);
   }
 }
 


### PR DESCRIPTION
This aligns the implementation with [spec version `62fe4c8` of 20 July 2020](https://streams.spec.whatwg.org/commit-snapshots/62fe4c8c0df34cec4ff28db9bfa69aec6c65e38d/).

Comparison: https://github.com/whatwg/streams/compare/caf3cea28134d8be2ec69b6a1105748a7c8d10b5...62fe4c8c0df34cec4ff28db9bfa69aec6c65e38d