### PR TITLE
Add documentation to type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 📝 Add documentation to type definitions ([#62](https://github.com/MattiasBuelens/web-streams-polyfill/pull/62))
+
 ## v3.0.0 (2020-07-20)
 
 * 💥 Align with [spec version `62fe4c8`](https://github.com/whatwg/streams/tree/62fe4c8c0df34cec4ff28db9bfa69aec6c65e38d/) ([#52](https://github.com/MattiasBuelens/web-streams-polyfill/pull/52), [#57](https://github.com/MattiasBuelens/web-streams-polyfill/pull/57), [#59](https://github.com/MattiasBuelens/web-streams-polyfill/pull/59))  

--- a/build/downlevel-dts.js
+++ b/build/downlevel-dts.js
@@ -32,7 +32,11 @@ function downlevelTS36(f) {
     const s = g.getSetAccessor();
     const returnTypeNode = g.getReturnTypeNode();
     const returnType = returnTypeNode ? returnTypeNode.getText() : 'any';
-    g.replaceWithText(`${getModifiersText(g)}${s ? '' : 'readonly '}${g.getName()}: ${returnType};`);
+    g.getParent().insertProperty(g.getChildIndex(), Object.assign({}, g.getStructure(), {
+      type: returnType,
+      isReadonly: !s
+    }));
+    g.remove();
     if (s) {
       s.remove();
     }
@@ -44,7 +48,11 @@ function downlevelTS36(f) {
       const firstParam = s.getParameters()[0];
       const firstParamTypeNode = firstParam && firstParam.getTypeNode();
       const firstParamType = firstParamTypeNode ? firstParamTypeNode.getText() : 'any';
-      s.replaceWithText(`${getModifiersText(s)}${s.getName()}: ${firstParamType};`);
+      s.getParent().insertProperty(s.getChildIndex(), Object.assign({}, s.getStructure(), {
+        type: firstParamType,
+        isReadonly: false
+      }));
+      s.remove();
     }
   }
 }
@@ -60,9 +68,4 @@ function downlevelTS34(f) {
       f.replaceText([r.getPos(), r.getEnd()], 'esnext.asynciterable');
     }
   }
-}
-
-function getModifiersText(node) {
-  const modifiersText = node.getModifiers().map(m => m.getText()).join(' ');
-  return modifiersText.length > 0 ? modifiersText + ' ' : '';
 }

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -6,11 +6,8 @@
 
 // @public
 export interface AbortSignal {
-    // (undocumented)
     readonly aborted: boolean;
-    // (undocumented)
     addEventListener(type: 'abort', listener: () => void): void;
-    // (undocumented)
     removeEventListener(type: 'abort', listener: () => void): void;
 }
 

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -74,21 +74,17 @@ export interface ReadableStreamAsyncIterator<R> extends AsyncIterator<R> {
     return(value?: any): Promise<IteratorResult<any>>;
 }
 
-// @public (undocumented)
+// @public
 export class ReadableStreamBYOBReader {
     // Warning: (ae-forgotten-export) The symbol "ReadableByteStream" needs to be exported by the entry point polyfill.d.ts
     constructor(stream: ReadableByteStream);
-    // (undocumented)
     cancel(reason?: any): Promise<void>;
-    // (undocumented)
     get closed(): Promise<void>;
-    // (undocumented)
     read<T extends ArrayBufferView>(view: T): Promise<ReadableStreamBYOBReadResult<T>>;
-    // (undocumented)
     releaseLock(): void;
 }
 
-// @public (undocumented)
+// @public
 export type ReadableStreamBYOBReadResult<T extends ArrayBufferView> = {
     done: boolean;
     value: T;

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -11,37 +11,29 @@ export interface AbortSignal {
     removeEventListener(type: 'abort', listener: () => void): void;
 }
 
-// @public (undocumented)
+// @public
 export class ByteLengthQueuingStrategy implements QueuingStrategy<ArrayBufferView> {
     constructor(options: QueuingStrategyInit);
-    // (undocumented)
     get highWaterMark(): number;
-    // (undocumented)
     get size(): (chunk: ArrayBufferView) => number;
 }
 
-// @public (undocumented)
+// @public
 export class CountQueuingStrategy implements QueuingStrategy<any> {
     constructor(options: QueuingStrategyInit);
-    // (undocumented)
     get highWaterMark(): number;
-    // (undocumented)
     get size(): (chunk: any) => 1;
 }
 
-// @public (undocumented)
+// @public
 export interface QueuingStrategy<T = any> {
-    // (undocumented)
     highWaterMark?: number;
     // Warning: (ae-forgotten-export) The symbol "QueuingStrategySizeCallback" needs to be exported by the entry point polyfill.d.ts
-    //
-    // (undocumented)
     size?: QueuingStrategySizeCallback<T>;
 }
 
 // @public (undocumented)
 export interface QueuingStrategyInit {
-    // (undocumented)
     highWaterMark: number;
 }
 

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -37,17 +37,12 @@ export interface QueuingStrategyInit {
     highWaterMark: number;
 }
 
-// @public (undocumented)
+// @public
 export class ReadableByteStreamController {
-    // (undocumented)
     get byobRequest(): ReadableStreamBYOBRequest | null;
-    // (undocumented)
     close(): void;
-    // (undocumented)
     get desiredSize(): number | null;
-    // (undocumented)
     enqueue(chunk: ArrayBufferView): void;
-    // (undocumented)
     error(e?: any): void;
 }
 
@@ -99,25 +94,18 @@ export type ReadableStreamBYOBReadResult<T extends ArrayBufferView> = {
     value: T;
 };
 
-// @public (undocumented)
+// @public
 export class ReadableStreamBYOBRequest {
-    // (undocumented)
     respond(bytesWritten: number): void;
-    // (undocumented)
     respondWithNewView(view: ArrayBufferView): void;
-    // (undocumented)
     get view(): ArrayBufferView | null;
 }
 
-// @public (undocumented)
+// @public
 export class ReadableStreamDefaultController<R> {
-    // (undocumented)
     close(): void;
-    // (undocumented)
     get desiredSize(): number | null;
-    // (undocumented)
     enqueue(chunk: R): void;
-    // (undocumented)
     error(e?: any): void;
 }
 

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -51,32 +51,23 @@ export class ReadableByteStreamController {
     error(e?: any): void;
 }
 
-// @public (undocumented)
+// @public
 export class ReadableStream<R = any> {
-    // (undocumented)
     [Symbol.asyncIterator]: (options?: ReadableStreamIteratorOptions) => ReadableStreamAsyncIterator<R>;
     constructor(underlyingSource: UnderlyingByteSource, strategy?: {
         highWaterMark?: number;
         size?: undefined;
     });
     constructor(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>);
-    // (undocumented)
     cancel(reason?: any): Promise<void>;
-    // (undocumented)
     getReader({ mode }: {
         mode: 'byob';
     }): ReadableStreamBYOBReader;
-    // (undocumented)
     getReader(): ReadableStreamDefaultReader<R>;
-    // (undocumented)
     get locked(): boolean;
-    // (undocumented)
     pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
-    // (undocumented)
     pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
-    // (undocumented)
     tee(): [ReadableStream<R>, ReadableStream<R>];
-    // (undocumented)
     values(options?: ReadableStreamIteratorOptions): ReadableStreamAsyncIterator<R>;
 }
 
@@ -166,15 +157,11 @@ export interface ReadableWritablePair<R, W> {
     writable: WritableStream<W>;
 }
 
-// @public (undocumented)
+// @public
 export interface StreamPipeOptions {
-    // (undocumented)
     preventAbort?: boolean;
-    // (undocumented)
     preventCancel?: boolean;
-    // (undocumented)
     preventClose?: boolean;
-    // (undocumented)
     signal?: AbortSignal;
 }
 

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -195,17 +195,13 @@ export type UnderlyingByteSourcePullCallback = (controller: ReadableByteStreamCo
 // @public (undocumented)
 export type UnderlyingByteSourceStartCallback = (controller: ReadableByteStreamController) => void | PromiseLike<void>;
 
-// @public (undocumented)
+// @public
 export interface UnderlyingSink<W = any> {
-    // (undocumented)
     abort?: UnderlyingSinkAbortCallback;
-    // (undocumented)
     close?: UnderlyingSinkCloseCallback;
-    // (undocumented)
     start?: UnderlyingSinkStartCallback;
     // (undocumented)
     type?: undefined;
-    // (undocumented)
     write?: UnderlyingSinkWriteCallback<W>;
 }
 
@@ -239,41 +235,29 @@ export type UnderlyingSourcePullCallback<R> = (controller: ReadableStreamDefault
 // @public (undocumented)
 export type UnderlyingSourceStartCallback<R> = (controller: ReadableStreamDefaultController<R>) => void | PromiseLike<void>;
 
-// @public (undocumented)
+// @public
 export class WritableStream<W = any> {
     constructor(underlyingSink?: UnderlyingSink<W>, strategy?: QueuingStrategy<W>);
-    // (undocumented)
     abort(reason?: any): Promise<void>;
-    // (undocumented)
     close(): Promise<void>;
-    // (undocumented)
     getWriter(): WritableStreamDefaultWriter<W>;
-    // (undocumented)
     get locked(): boolean;
 }
 
-// @public (undocumented)
+// @public
 export class WritableStreamDefaultController<W = any> {
-    // (undocumented)
     error(e?: any): void;
 }
 
-// @public (undocumented)
+// @public
 export class WritableStreamDefaultWriter<W = any> {
     constructor(stream: WritableStream<W>);
-    // (undocumented)
     abort(reason?: any): Promise<void>;
-    // (undocumented)
     close(): Promise<void>;
-    // (undocumented)
     get closed(): Promise<void>;
-    // (undocumented)
     get desiredSize(): number | null;
-    // (undocumented)
     get ready(): Promise<void>;
-    // (undocumented)
     releaseLock(): void;
-    // (undocumented)
     write(chunk: W): Promise<void>;
 }
 

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -189,17 +189,12 @@ export class TransformStreamDefaultController<O> {
     terminate(): void;
 }
 
-// @public (undocumented)
+// @public
 export interface UnderlyingByteSource {
-    // (undocumented)
     autoAllocateChunkSize?: number;
-    // (undocumented)
     cancel?: UnderlyingSourceCancelCallback;
-    // (undocumented)
     pull?: UnderlyingByteSourcePullCallback;
-    // (undocumented)
     start?: UnderlyingByteSourceStartCallback;
-    // (undocumented)
     type: 'bytes';
 }
 
@@ -235,13 +230,10 @@ export type UnderlyingSinkStartCallback = (controller: WritableStreamDefaultCont
 // @public (undocumented)
 export type UnderlyingSinkWriteCallback<W> = (chunk: W, controller: WritableStreamDefaultController) => void | PromiseLike<void>;
 
-// @public (undocumented)
+// @public
 export interface UnderlyingSource<R = any> {
-    // (undocumented)
     cancel?: UnderlyingSourceCancelCallback;
-    // (undocumented)
     pull?: UnderlyingSourcePullCallback<R>;
-    // (undocumented)
     start?: UnderlyingSourceStartCallback<R>;
     // (undocumented)
     type?: undefined;

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -145,15 +145,12 @@ export interface StreamPipeOptions {
     signal?: AbortSignal;
 }
 
-// @public (undocumented)
+// @public
 export interface Transformer<I = any, O = any> {
-    // (undocumented)
     flush?: TransformerFlushCallback<O>;
     // (undocumented)
     readableType?: undefined;
-    // (undocumented)
     start?: TransformerStartCallback<O>;
-    // (undocumented)
     transform?: TransformerTransformCallback<I, O>;
     // (undocumented)
     writableType?: undefined;
@@ -168,24 +165,18 @@ export type TransformerStartCallback<O> = (controller: TransformStreamDefaultCon
 // @public (undocumented)
 export type TransformerTransformCallback<I, O> = (chunk: I, controller: TransformStreamDefaultController<O>) => void | PromiseLike<void>;
 
-// @public (undocumented)
+// @public
 export class TransformStream<I = any, O = any> {
     constructor(transformer?: Transformer<I, O>, writableStrategy?: QueuingStrategy<I>, readableStrategy?: QueuingStrategy<O>);
-    // (undocumented)
     get readable(): ReadableStream<O>;
-    // (undocumented)
     get writable(): WritableStream<I>;
 }
 
-// @public (undocumented)
+// @public
 export class TransformStreamDefaultController<O> {
-    // (undocumented)
     get desiredSize(): number | null;
-    // (undocumented)
     enqueue(chunk: O): void;
-    // (undocumented)
     error(reason?: any): void;
-    // (undocumented)
     terminate(): void;
 }
 

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -121,20 +121,16 @@ export class ReadableStreamDefaultController<R> {
     error(e?: any): void;
 }
 
-// @public (undocumented)
+// @public
 export class ReadableStreamDefaultReader<R = any> {
     constructor(stream: ReadableStream<R>);
-    // (undocumented)
     cancel(reason?: any): Promise<void>;
-    // (undocumented)
     get closed(): Promise<void>;
-    // (undocumented)
     read(): Promise<ReadableStreamDefaultReadResult<R>>;
-    // (undocumented)
     releaseLock(): void;
 }
 
-// @public (undocumented)
+// @public
 export type ReadableStreamDefaultReadResult<T> = {
     done: false;
     value: T;

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -71,7 +71,7 @@ export class ReadableStream<R = any> {
     values(options?: ReadableStreamIteratorOptions): ReadableStreamAsyncIterator<R>;
 }
 
-// @public (undocumented)
+// @public
 export interface ReadableStreamAsyncIterator<R> extends AsyncIterator<R> {
     // (undocumented)
     next(): Promise<IteratorResult<R>>;

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -123,13 +123,13 @@ export type ReadableStreamDefaultReadResult<T> = {
     value: undefined;
 };
 
-// @public (undocumented)
+// @public
 export interface ReadableStreamIteratorOptions {
     // (undocumented)
     preventCancel?: boolean;
 }
 
-// @public (undocumented)
+// @public
 export interface ReadableWritablePair<R, W> {
     // (undocumented)
     readable: ReadableStream<R>;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "lint": "eslint \"src/**/*.ts\"",
     "build": "npm run build:bundle && npm run build:types",
     "build:bundle": "rollup -c",
-    "build:types": "tsc --project . --emitDeclarationOnly --declarationDir ./lib && api-extractor run --local && node ./build/downlevel-dts.js",
+    "build:types": "tsc --project . --emitDeclarationOnly --declarationDir ./lib && api-extractor run && node ./build/downlevel-dts.js",
+    "accept:types": "tsc --project . --emitDeclarationOnly --declarationDir ./lib && api-extractor run --local && node ./build/downlevel-dts.js",
     "prepare": "npm run build"
   },
   "files": [

--- a/src/lib/abort-signal.ts
+++ b/src/lib/abort-signal.ts
@@ -6,12 +6,23 @@
  *   This interface is compatible with the `AbortSignal` interface defined in TypeScript's DOM types.
  *   It is redefined here, so it can be polyfilled without a DOM, for example with
  *   {@link https://www.npmjs.com/package/abortcontroller-polyfill | abortcontroller-polyfill} in a Node environment.
+ *
+ * @public
  */
 export interface AbortSignal {
+  /**
+   * Whether the request is aborted.
+   */
   readonly aborted: boolean;
 
+  /**
+   * Add an event listener to be triggered when this signal becomes aborted.
+   */
   addEventListener(type: 'abort', listener: () => void): void;
 
+  /**
+   * Remove an event listener that was previously added with {@link AbortSignal.addEventListener}.
+   */
   removeEventListener(type: 'abort', listener: () => void): void;
 }
 

--- a/src/lib/byte-length-queuing-strategy.ts
+++ b/src/lib/byte-length-queuing-strategy.ts
@@ -7,6 +7,11 @@ const byteLengthSizeFunction = function size(chunk: ArrayBufferView): number {
   return chunk.byteLength;
 };
 
+/**
+ * A queuing strategy that counts the number of bytes in each chunk.
+ *
+ * @public
+ */
 export default class ByteLengthQueuingStrategy implements QueuingStrategy<ArrayBufferView> {
   /** @internal */
   readonly _byteLengthQueuingStrategyHighWaterMark: number;
@@ -17,6 +22,9 @@ export default class ByteLengthQueuingStrategy implements QueuingStrategy<ArrayB
     this._byteLengthQueuingStrategyHighWaterMark = options.highWaterMark;
   }
 
+  /**
+   * Returns the high water mark provided to the constructor.
+   */
   get highWaterMark(): number {
     if (!IsByteLengthQueuingStrategy(this)) {
       throw byteLengthBrandCheckException('highWaterMark');
@@ -24,6 +32,9 @@ export default class ByteLengthQueuingStrategy implements QueuingStrategy<ArrayB
     return this._byteLengthQueuingStrategyHighWaterMark;
   }
 
+  /**
+   * Measures the size of `chunk` by returning the value of its `byteLength` property.
+   */
   get size(): (chunk: ArrayBufferView) => number {
     if (!IsByteLengthQueuingStrategy(this)) {
       throw byteLengthBrandCheckException('size');

--- a/src/lib/count-queuing-strategy.ts
+++ b/src/lib/count-queuing-strategy.ts
@@ -7,6 +7,11 @@ const countSizeFunction = function size(): 1 {
   return 1;
 };
 
+/**
+ * A queuing strategy that counts the number of chunks.
+ *
+ * @public
+ */
 export default class CountQueuingStrategy implements QueuingStrategy<any> {
   /** @internal */
   readonly _countQueuingStrategyHighWaterMark!: number;
@@ -17,6 +22,9 @@ export default class CountQueuingStrategy implements QueuingStrategy<any> {
     this._countQueuingStrategyHighWaterMark = options.highWaterMark;
   }
 
+  /**
+   * Returns the high water mark provided to the constructor.
+   */
   get highWaterMark(): number {
     if (!IsCountQueuingStrategy(this)) {
       throw countBrandCheckException('highWaterMark');
@@ -24,6 +32,10 @@ export default class CountQueuingStrategy implements QueuingStrategy<any> {
     return this._countQueuingStrategyHighWaterMark;
   }
 
+  /**
+   * Measures the size of `chunk` by always returning 1.
+   * This ensures that the total queue size is a count of the number of chunks in the queue.
+   */
   get size(): (chunk: any) => 1 {
     if (!IsCountQueuingStrategy(this)) {
       throw countBrandCheckException('size');

--- a/src/lib/queuing-strategy.ts
+++ b/src/lib/queuing-strategy.ts
@@ -1,10 +1,27 @@
 export type QueuingStrategySizeCallback<T = any> = (chunk: T) => number;
 
+/**
+ * @public
+ */
 export interface QueuingStrategyInit {
+  /**
+   * {@inheritDoc QueuingStrategy.highWaterMark}
+   */
   highWaterMark: number;
 }
 
+/**
+ * A queuing strategy.
+ *
+ * @public
+ */
 export interface QueuingStrategy<T = any> {
+  /**
+   * A non-negative number indicating the high water mark of the stream using this queuing strategy.
+   */
   highWaterMark?: number;
+  /**
+   * A function that computes and returns the finite non-negative size of the given chunk value.
+   */
   size?: QueuingStrategySizeCallback<T>;
 }

--- a/src/lib/readable-stream/async-iterator.ts
+++ b/src/lib/readable-stream/async-iterator.ts
@@ -24,6 +24,11 @@ import {
   transformPromiseWith
 } from '../helpers/webidl';
 
+/**
+ * An async iterator returned by {@link ReadableStream.values}.
+ *
+ * @public
+ */
 export interface ReadableStreamAsyncIterator<R> extends AsyncIterator<R> {
   next(): Promise<IteratorResult<R>>;
 

--- a/src/lib/readable-stream/default-controller.ts
+++ b/src/lib/readable-stream/default-controller.ts
@@ -14,6 +14,11 @@ import { typeIsObject } from '../helpers/miscellaneous';
 import { CancelSteps, PullSteps } from '../abstract-ops/internal-methods';
 import { promiseResolvedWith, uponPromise } from '../helpers/webidl';
 
+/**
+ * Allows control of a {@link ReadableStream | readable stream}'s state and internal queue.
+ *
+ * @public
+ */
 export class ReadableStreamDefaultController<R> {
   /** @internal */
   _controlledReadableStream!: ReadableStream<R>;
@@ -42,6 +47,10 @@ export class ReadableStreamDefaultController<R> {
     throw new TypeError('Illegal constructor');
   }
 
+  /**
+   * Returns the desired size to fill the controlled stream's internal queue. It can be negative, if the queue is
+   * over-full. An underlying source ought to use this information to determine when and how to apply backpressure.
+   */
   get desiredSize(): number | null {
     if (!IsReadableStreamDefaultController(this)) {
       throw defaultControllerBrandCheckException('desiredSize');
@@ -50,6 +59,10 @@ export class ReadableStreamDefaultController<R> {
     return ReadableStreamDefaultControllerGetDesiredSize(this);
   }
 
+  /**
+   * Closes the controlled readable stream. Consumers will still be able to read any previously-enqueued chunks from
+   * the stream, but once those are read, the stream will become closed.
+   */
   close(): void {
     if (!IsReadableStreamDefaultController(this)) {
       throw defaultControllerBrandCheckException('close');
@@ -62,6 +75,9 @@ export class ReadableStreamDefaultController<R> {
     ReadableStreamDefaultControllerClose(this);
   }
 
+  /**
+   * Enqueues the given chunk `chunk` in the controlled readable stream.
+   */
   enqueue(chunk: R): void;
   enqueue(chunk: R = undefined!): void {
     if (!IsReadableStreamDefaultController(this)) {
@@ -75,6 +91,9 @@ export class ReadableStreamDefaultController<R> {
     return ReadableStreamDefaultControllerEnqueue(this, chunk);
   }
 
+  /**
+   * Errors the controlled readable stream, making all future interactions with it fail with the given error `e`.
+   */
   error(e: any = undefined): void {
     if (!IsReadableStreamDefaultController(this)) {
       throw defaultControllerBrandCheckException('error');

--- a/src/lib/readable-stream/iterator-options.ts
+++ b/src/lib/readable-stream/iterator-options.ts
@@ -1,3 +1,8 @@
+/**
+ * Options for {@link ReadableStream.values | async iterating} a stream.
+ *
+ * @public
+ */
 export interface ReadableStreamIteratorOptions {
   preventCancel?: boolean;
 }

--- a/src/lib/readable-stream/pipe-options.ts
+++ b/src/lib/readable-stream/pipe-options.ts
@@ -1,9 +1,29 @@
 import { AbortSignal } from '../abort-signal';
 
+/**
+ * Options for {@link ReadableStream.pipeTo | piping} a stream.
+ *
+ * @public
+ */
 export interface StreamPipeOptions {
+  /**
+   * If set to true, {@link ReadableStream.pipeTo} will not abort the writable stream if the readable stream errors.
+   */
   preventAbort?: boolean;
+  /**
+   * If set to true, {@link ReadableStream.pipeTo} will not cancel the readable stream if the writable stream closes
+   * or errors.
+   */
   preventCancel?: boolean;
+  /**
+   * If set to true, {@link ReadableStream.pipeTo} will not close the writable stream if the readable stream closes.
+   */
   preventClose?: boolean;
+  /**
+   * Can be set to an {@link AbortSignal} to allow aborting an ongoing pipe operation via the corresponding
+   * `AbortController`. In this case, the source readable stream will be canceled, and the destination writable stream
+   * aborted, unless the respective options `preventCancel` or `preventAbort` are set.
+   */
   signal?: AbortSignal;
 }
 

--- a/src/lib/readable-stream/readable-writable-pair.ts
+++ b/src/lib/readable-stream/readable-writable-pair.ts
@@ -1,6 +1,12 @@
 import { ReadableStream } from '../readable-stream';
 import { WritableStream } from '../writable-stream';
 
+/**
+ * A pair of a {@link ReadableStream | readable stream} and {@link WritableStream | writable stream} that can be passed
+ * to {@link ReadableStream.pipeThrough}.
+ *
+ * @public
+ */
 export interface ReadableWritablePair<R, W> {
   readable: ReadableStream<R>;
   writable: WritableStream<W>;

--- a/src/lib/readable-stream/underlying-source.ts
+++ b/src/lib/readable-stream/underlying-source.ts
@@ -5,26 +5,79 @@ export type ReadableStreamController<R = any> = ReadableStreamDefaultController<
 export type UnderlyingDefaultOrByteSourceStartCallback<R> = (controller: ReadableStreamController<R>) => void | PromiseLike<void>;
 export type UnderlyingDefaultOrByteSourcePullCallback<R> = (controller: ReadableStreamController<R>) => void | PromiseLike<void>;
 
+/** @public */
 export type UnderlyingSourceStartCallback<R> = (controller: ReadableStreamDefaultController<R>) => void | PromiseLike<void>;
+/** @public */
 export type UnderlyingSourcePullCallback<R> = (controller: ReadableStreamDefaultController<R>) => void | PromiseLike<void>;
+/** @public */
 export type UnderlyingByteSourceStartCallback = (controller: ReadableByteStreamController) => void | PromiseLike<void>;
+/** @public */
 export type UnderlyingByteSourcePullCallback = (controller: ReadableByteStreamController) => void | PromiseLike<void>;
+/** @public */
 export type UnderlyingSourceCancelCallback = (reason: any) => void | PromiseLike<void>;
 
 export type ReadableStreamType = 'bytes';
 
+/**
+ * An underlying source for constructing a {@link ReadableStream}.
+ *
+ * @public
+ */
 export interface UnderlyingSource<R = any> {
+  /**
+   * A function that is called immediately during creation of the {@link ReadableStream}.
+   */
   start?: UnderlyingSourceStartCallback<R>;
+  /**
+   * A function that is called whenever the stream’s internal queue of chunks becomes not full,
+   * i.e. whenever the queue’s desired size becomes positive. Generally, it will be called repeatedly
+   * until the queue reaches its high water mark (i.e. until the desired size becomes non-positive).
+   */
   pull?: UnderlyingSourcePullCallback<R>;
+  /**
+   * A function that is called whenever the consumer cancels the stream, via
+   * {@link ReadableStream.cancel | stream.cancel()},
+   * {@link ReadableStreamDefaultReader.cancel | defaultReader.cancel()}, or
+   * {@link ReadableStreamBYOBReader.cancel | byobReader.cancel()}.
+   * It takes as its argument the same value as was passed to those methods by the consumer.
+   */
   cancel?: UnderlyingSourceCancelCallback;
   type?: undefined;
 }
 
+/**
+ * An underlying byte source for constructing a {@link ReadableStream}.
+ *
+ * @public
+ */
 export interface UnderlyingByteSource {
+  /**
+   * {@inheritDoc UnderlyingSource.start}
+   */
   start?: UnderlyingByteSourceStartCallback;
+  /**
+   * {@inheritDoc UnderlyingSource.pull}
+   */
   pull?: UnderlyingByteSourcePullCallback;
+  /**
+   * {@inheritDoc UnderlyingSource.cancel}
+   */
   cancel?: UnderlyingSourceCancelCallback;
+  /**
+   * Can be set to "bytes" to signal that the constructed {@link ReadableStream} is a readable byte stream.
+   * This ensures that the resulting {@link ReadableStream} will successfully be able to vend BYOB readers via its
+   * {@link ReadableStream.(getReader:1) | getReader()} method.
+   * It also affects the controller argument passed to the {@link UnderlyingByteSource.start | start()}
+   * and {@link UnderlyingByteSource.pull | pull()} methods.
+   */
   type: 'bytes';
+  /**
+   * Can be set to a positive integer to cause the implementation to automatically allocate buffers for the
+   * underlying source code to write into. In this case, when a consumer is using a default reader, the stream
+   * implementation will automatically allocate an ArrayBuffer of the given size, so that
+   * {@link ReadableByteStreamController.byobRequest | controller.byobRequest} is always present,
+   * as if the consumer was using a BYOB reader.
+   */
   autoAllocateChunkSize?: number;
 }
 

--- a/src/lib/transform-stream.ts
+++ b/src/lib/transform-stream.ts
@@ -26,6 +26,14 @@ import { convertTransformer } from './validators/transformer';
 
 // Class TransformStream
 
+/**
+ * A transform stream consists of a pair of streams: a {@link WritableStream | writable stream},
+ * known as its writable side, and a {@link ReadableStream | readable stream}, known as its readable side.
+ * In a manner specific to the transform stream in question, writes to the writable side result in new data being
+ * made available for reading from the readable side.
+ *
+ * @public
+ */
 export class TransformStream<I = any, O = any> {
   /** @internal */
   _writable!: WritableStream<I>;
@@ -85,6 +93,9 @@ export class TransformStream<I = any, O = any> {
     }
   }
 
+  /**
+   * The readable side of the transform stream.
+   */
   get readable(): ReadableStream<O> {
     if (!IsTransformStream(this)) {
       throw streamBrandCheckException('readable');
@@ -93,6 +104,9 @@ export class TransformStream<I = any, O = any> {
     return this._readable;
   }
 
+  /**
+   * The writable side of the transform stream.
+   */
   get writable(): WritableStream<I> {
     if (!IsTransformStream(this)) {
       throw streamBrandCheckException('writable');
@@ -244,6 +258,11 @@ function TransformStreamSetBackpressure(stream: TransformStream, backpressure: b
 
 // Class TransformStreamDefaultController
 
+/**
+ * Allows control of the {@link ReadableStream} and {@link WritableStream} of the associated {@link TransformStream}.
+ *
+ * @public
+ */
 export class TransformStreamDefaultController<O> {
   /** @internal */
   _controlledTransformStream: TransformStream<any, O>;
@@ -256,6 +275,9 @@ export class TransformStreamDefaultController<O> {
     throw new TypeError('Illegal constructor');
   }
 
+  /**
+   * Returns the desired size to fill the readable side’s internal queue. It can be negative, if the queue is over-full.
+   */
   get desiredSize(): number | null {
     if (!IsTransformStreamDefaultController(this)) {
       throw defaultControllerBrandCheckException('desiredSize');
@@ -265,6 +287,9 @@ export class TransformStreamDefaultController<O> {
     return ReadableStreamDefaultControllerGetDesiredSize(readableController as ReadableStreamDefaultController<O>);
   }
 
+  /**
+   * Enqueues the given chunk `chunk` in the readable side of the controlled transform stream.
+   */
   enqueue(chunk: O): void;
   enqueue(chunk: O = undefined!): void {
     if (!IsTransformStreamDefaultController(this)) {
@@ -274,6 +299,10 @@ export class TransformStreamDefaultController<O> {
     TransformStreamDefaultControllerEnqueue(this, chunk);
   }
 
+  /**
+   * Errors both the readable side and the writable side of the controlled transform stream, making all future
+   * interactions with it fail with the given error `e`. Any chunks queued for transformation will be discarded.
+   */
   error(reason: any = undefined): void {
     if (!IsTransformStreamDefaultController(this)) {
       throw defaultControllerBrandCheckException('error');
@@ -282,6 +311,10 @@ export class TransformStreamDefaultController<O> {
     TransformStreamDefaultControllerError(this, reason);
   }
 
+  /**
+   * Closes the readable side and errors the writable side of the controlled transform stream. This is useful when the
+   * transformer only needs to consume a portion of the chunks written to the writable side.
+   */
   terminate(): void {
     if (!IsTransformStreamDefaultController(this)) {
       throw defaultControllerBrandCheckException('terminate');

--- a/src/lib/transform-stream/transformer.ts
+++ b/src/lib/transform-stream/transformer.ts
@@ -1,15 +1,33 @@
 import { TransformStreamDefaultController } from '../transform-stream';
 
+/** @public */
 export type TransformerStartCallback<O>
   = (controller: TransformStreamDefaultController<O>) => void | PromiseLike<void>;
+/** @public */
 export type TransformerFlushCallback<O>
   = (controller: TransformStreamDefaultController<O>) => void | PromiseLike<void>;
+/** @public */
 export type TransformerTransformCallback<I, O>
   = (chunk: I, controller: TransformStreamDefaultController<O>) => void | PromiseLike<void>;
 
+/**
+ * A transformer for constructing a {@link TransformStream}.
+ *
+ * @public
+ */
 export interface Transformer<I = any, O = any> {
+  /**
+   * A function that is called immediately during creation of the {@link TransformStream}.
+   */
   start?: TransformerStartCallback<O>;
+  /**
+   * A function called when a new chunk originally written to the writable side is ready to be transformed.
+   */
   transform?: TransformerTransformCallback<I, O>;
+  /**
+   * A function called after all chunks written to the writable side have been transformed by successfully passing
+   * through {@link Transformer.transform | transform()}, and the writable side is about to be closed.
+   */
   flush?: TransformerFlushCallback<O>;
   readableType?: undefined;
   writableType?: undefined;

--- a/src/lib/writable-stream/underlying-sink.ts
+++ b/src/lib/writable-stream/underlying-sink.ts
@@ -1,16 +1,56 @@
 import { WritableStreamDefaultController } from '../writable-stream';
 
+/** @public */
 export type UnderlyingSinkStartCallback
   = (controller: WritableStreamDefaultController) => void | PromiseLike<void>;
+/** @public */
 export type UnderlyingSinkWriteCallback<W>
   = (chunk: W, controller: WritableStreamDefaultController) => void | PromiseLike<void>;
+/** @public */
 export type UnderlyingSinkCloseCallback = () => void | PromiseLike<void>;
+/** @public */
 export type UnderlyingSinkAbortCallback = (reason: any) => void | PromiseLike<void>;
 
+/**
+ * An underlying sink for constructing a {@link WritableStream}.
+ *
+ * @public
+ */
 export interface UnderlyingSink<W = any> {
+  /**
+   * A function that is called immediately during creation of the {@link WritableStream}.
+   */
   start?: UnderlyingSinkStartCallback;
+  /**
+   * A function that is called when a new chunk of data is ready to be written to the underlying sink. The stream
+   * implementation guarantees that this function will be called only after previous writes have succeeded, and never
+   * before {@link UnderlyingSink.start | start()} has succeeded or after {@link UnderlyingSink.close | close()} or
+   * {@link UnderlyingSink.abort | abort()} have been called.
+   *
+   * This function is used to actually send the data to the resource presented by the underlying sink, for example by
+   * calling a lower-level API.
+   */
   write?: UnderlyingSinkWriteCallback<W>;
+  /**
+   * A function that is called after the producer signals, via
+   * {@link WritableStreamDefaultWriter.close | writer.close()}, that they are done writing chunks to the stream, and
+   * subsequently all queued-up writes have successfully completed.
+   *
+   * This function can perform any actions necessary to finalize or flush writes to the underlying sink, and release
+   * access to any held resources.
+   */
   close?: UnderlyingSinkCloseCallback;
+  /**
+   * A function that is called after the producer signals, via {@link WritableStream.abort | stream.abort()} or
+   * {@link WritableStreamDefaultWriter.abort | writer.abort()}, that they wish to abort the stream. It takes as its
+   * argument the same value as was passed to those methods by the producer.
+   *
+   * Writable streams can additionally be aborted under certain conditions during piping; see the definition of the
+   * {@link ReadableStream.pipeTo | pipeTo()} method for more details.
+   *
+   * This function can clean up any held resources, much like {@link UnderlyingSink.close | close()}, but perhaps with
+   * some custom handling.
+   */
   abort?: UnderlyingSinkAbortCallback;
   type?: undefined;
 }


### PR DESCRIPTION
This adds documentation to all exported types in the public type definitions. The documentation was copied for a large part from the "For web developers (non-normative)" sections of [the streams specification](https://streams.spec.whatwg.org/).