### PR TITLE
Update to spec version of 5 August 2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## Unreleased
 
 * 📝 Add documentation to type definitions ([#62](https://github.com/MattiasBuelens/web-streams-polyfill/pull/62))
+* 👓 Align with [spec version `6cd5e81`](https://github.com/whatwg/streams/tree/6cd5e81f6191fed9e7d99ee73d4941e3060311ce/) ([#63](https://github.com/MattiasBuelens/web-streams-polyfill/pull/63))
 
 ## v3.0.0 (2020-07-20)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `polyfill/es2018` and `ponyfill/es2018` variants work in any ES2018-compatib
 
 ### Compliance
 
-The polyfill implements [version `62fe4c8` (20 Jul 2020)][spec-snapshot] of the streams specification.
+The polyfill implements [version `6cd5e81` (5 Aug 2020)][spec-snapshot] of the streams specification.
 
 The polyfill is tested against the same [web platform tests][wpt] that are used by browsers to test their native implementations.
 The polyfill aims to pass all tests, although it allows some exceptions for practical reasons:
@@ -99,12 +99,12 @@ Thanks to these people for their work on [the original polyfill][creatorrr-polyf
 [promise-support]: https://kangax.github.io/compat-table/es6/#test-Promise
 [promise-polyfill]: https://www.npmjs.com/package/promise-polyfill
 [rs-asynciterator]: https://streams.spec.whatwg.org/#rs-asynciterator
-[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/62fe4c8c0df34cec4ff28db9bfa69aec6c65e38d/
+[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/6cd5e81f6191fed9e7d99ee73d4941e3060311ce/
 [wpt]: https://github.com/web-platform-tests/wpt/tree/c5f9e701753a034f99dda16d4716c465bed73e18/streams
 [wpt-bad-buffers]: https://github.com/web-platform-tests/wpt/blob/c5f9e701753a034f99dda16d4716c465bed73e18/streams/readable-byte-streams/bad-buffers-and-views.any.js
 [proposal-arraybuffer-transfer]: https://github.com/domenic/proposal-arraybuffer-transfer
-[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/62fe4c8c0df34cec4ff28db9bfa69aec6c65e38d/reference-implementation/lib/abstract-ops/ecmascript.js#L16
+[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/6cd5e81f6191fed9e7d99ee73d4941e3060311ce/reference-implementation/lib/abstract-ops/ecmascript.js#L16
 [issue-3]: https://github.com/MattiasBuelens/web-streams-polyfill/issues/3
-[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/c5f9e701753a034f99dda16d4716c465bed73e18/streams/readable-streams/async-iterator.any.js#L28
+[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/e5e5e7a10cbb968b31c51ad87ce8a3da62bb1b34/streams/readable-streams/async-iterator.any.js#L24
 [stub-async-iterator-prototype]: https://github.com/MattiasBuelens/web-streams-polyfill/blob/v2.0.0/src/target/es5/stub/async-iterator-prototype.ts
 [creatorrr-polyfill]: https://github.com/creatorrr/web-streams-polyfill

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -695,16 +695,16 @@ function ReadableByteStreamControllerRespondInReadableState(controller: Readable
 function ReadableByteStreamControllerRespondInternal(controller: ReadableByteStreamController, bytesWritten: number) {
   const firstDescriptor = controller._pendingPullIntos.peek();
 
-  const stream = controller._controlledReadableByteStream;
+  const state = controller._controlledReadableByteStream._state;
 
-  if (stream._state === 'closed') {
+  if (state === 'closed') {
     if (bytesWritten !== 0) {
       throw new TypeError('bytesWritten must be 0 when calling respond() on a closed stream');
     }
 
     ReadableByteStreamControllerRespondInClosedState(controller, firstDescriptor);
   } else {
-    assert(stream._state === 'readable');
+    assert(state === 'readable');
 
     ReadableByteStreamControllerRespondInReadableState(controller, bytesWritten, firstDescriptor);
   }
@@ -832,8 +832,7 @@ function ReadableByteStreamControllerError(controller: ReadableByteStreamControl
 }
 
 function ReadableByteStreamControllerGetDesiredSize(controller: ReadableByteStreamController): number | null {
-  const stream = controller._controlledReadableByteStream;
-  const state = stream._state;
+  const state = controller._controlledReadableByteStream._state;
 
   if (state === 'errored') {
     return null;

--- a/src/lib/readable-stream/default-controller.ts
+++ b/src/lib/readable-stream/default-controller.ts
@@ -281,8 +281,7 @@ export function ReadableStreamDefaultControllerError(controller: ReadableStreamD
 }
 
 export function ReadableStreamDefaultControllerGetDesiredSize(controller: ReadableStreamDefaultController<any>): number | null {
-  const stream = controller._controlledReadableStream;
-  const state = stream._state;
+  const state = controller._controlledReadableStream._state;
 
   if (state === 'errored') {
     return null;

--- a/src/lib/readable-stream/tee.ts
+++ b/src/lib/readable-stream/tee.ts
@@ -66,6 +66,8 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
               value2
             );
           }
+
+          resolveCancelPromise(undefined);
         });
       },
       _closeSteps: () => {
@@ -118,6 +120,7 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
   uponRejection(reader._closedPromise, (r: any) => {
     ReadableStreamDefaultControllerError(branch1._readableStreamController as ReadableStreamDefaultController<R>, r);
     ReadableStreamDefaultControllerError(branch2._readableStreamController as ReadableStreamDefaultController<R>, r);
+    resolveCancelPromise(undefined);
   });
 
   return [branch1, branch2];

--- a/test/run-web-platform-tests.js
+++ b/test/run-web-platform-tests.js
@@ -37,7 +37,9 @@ async function main() {
   const excludedTests = [
     // We cannot polyfill TransferArrayBuffer yet, so disable tests for detached array buffers
     // See https://github.com/MattiasBuelens/web-streams-polyfill/issues/3
-    'readable-byte-streams/bad-buffers-and-views.any.html'
+    'readable-byte-streams/bad-buffers-and-views.any.html',
+    // Disable tests for different size functions per realm, since they need a working <iframe>
+    'queuing-strategies-size-function-per-global.window.html'
   ];
   const ignoredFailures = {};
 


### PR DESCRIPTION
This aligns the implementation with [spec version `6cd5e81` of 5 August 2020](https://streams.spec.whatwg.org/commit-snapshots/6cd5e81f6191fed9e7d99ee73d4941e3060311ce/).

Comparison: https://github.com/whatwg/streams/compare/62fe4c8c0df34cec4ff28db9bfa69aec6c65e38d...6cd5e81f6191fed9e7d99ee73d4941e3060311ce