### PR TITLE
Update to spec version of 8 February 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 👓 Align with [spec version `200c971`](https://github.com/whatwg/streams/tree/200c971563b1a695fce3eebe6dab45c348ff0ac0/) ([#69](https://github.com/MattiasBuelens/web-streams-polyfill/pull/69))
+
 ## v3.0.1 (2020-11-12)
 
 * 📝 Add documentation to type definitions ([#62](https://github.com/MattiasBuelens/web-streams-polyfill/pull/62))

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `polyfill/es2018` and `ponyfill/es2018` variants work in any ES2018-compatib
 
 ### Compliance
 
-The polyfill implements [version `6cd5e81` (5 Aug 2020)][spec-snapshot] of the streams specification.
+The polyfill implements [version `200c971` (8 Feb 2021)][spec-snapshot] of the streams specification.
 
 The polyfill is tested against the same [web platform tests][wpt] that are used by browsers to test their native implementations.
 The polyfill aims to pass all tests, although it allows some exceptions for practical reasons:
@@ -99,12 +99,12 @@ Thanks to these people for their work on [the original polyfill][creatorrr-polyf
 [promise-support]: https://kangax.github.io/compat-table/es6/#test-Promise
 [promise-polyfill]: https://www.npmjs.com/package/promise-polyfill
 [rs-asynciterator]: https://streams.spec.whatwg.org/#rs-asynciterator
-[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/6cd5e81f6191fed9e7d99ee73d4941e3060311ce/
-[wpt]: https://github.com/web-platform-tests/wpt/tree/c5f9e701753a034f99dda16d4716c465bed73e18/streams
-[wpt-bad-buffers]: https://github.com/web-platform-tests/wpt/blob/c5f9e701753a034f99dda16d4716c465bed73e18/streams/readable-byte-streams/bad-buffers-and-views.any.js
+[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/200c971563b1a695fce3eebe6dab45c348ff0ac0/
+[wpt]: https://github.com/web-platform-tests/wpt/tree/7e94a4bcb5bd6808e08ed8db46fa63751543db52/streams
+[wpt-bad-buffers]: https://github.com/web-platform-tests/wpt/blob/7e94a4bcb5bd6808e08ed8db46fa63751543db52/streams/readable-byte-streams/bad-buffers-and-views.any.js
 [proposal-arraybuffer-transfer]: https://github.com/domenic/proposal-arraybuffer-transfer
-[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/6cd5e81f6191fed9e7d99ee73d4941e3060311ce/reference-implementation/lib/abstract-ops/ecmascript.js#L16
+[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/200c971563b1a695fce3eebe6dab45c348ff0ac0/reference-implementation/lib/abstract-ops/ecmascript.js#L16
 [issue-3]: https://github.com/MattiasBuelens/web-streams-polyfill/issues/3
-[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/e5e5e7a10cbb968b31c51ad87ce8a3da62bb1b34/streams/readable-streams/async-iterator.any.js#L24
+[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/7e94a4bcb5bd6808e08ed8db46fa63751543db52/streams/readable-streams/async-iterator.any.js#L24
 [stub-async-iterator-prototype]: https://github.com/MattiasBuelens/web-streams-polyfill/blob/v2.0.0/src/target/es5/stub/async-iterator-prototype.ts
 [creatorrr-polyfill]: https://github.com/creatorrr/web-streams-polyfill

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -461,14 +461,14 @@ export function ReadableStreamClose<R>(stream: ReadableStream<R>): void {
     return;
   }
 
+  defaultReaderClosedPromiseResolve(reader);
+
   if (IsReadableStreamDefaultReader<R>(reader)) {
     reader._readRequests.forEach(readRequest => {
       readRequest._closeSteps();
     });
     reader._readRequests = new SimpleQueue();
   }
-
-  defaultReaderClosedPromiseResolve(reader);
 }
 
 export function ReadableStreamError<R>(stream: ReadableStream<R>, e: any): void {
@@ -483,6 +483,8 @@ export function ReadableStreamError<R>(stream: ReadableStream<R>, e: any): void 
   if (reader === undefined) {
     return;
   }
+
+  defaultReaderClosedPromiseReject(reader, e);
 
   if (IsReadableStreamDefaultReader<R>(reader)) {
     reader._readRequests.forEach(readRequest => {
@@ -499,8 +501,6 @@ export function ReadableStreamError<R>(stream: ReadableStream<R>, e: any): void 
 
     reader._readIntoRequests = new SimpleQueue();
   }
-
-  defaultReaderClosedPromiseReject(reader, e);
 }
 
 // Readers

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -950,6 +950,9 @@ export function SetUpReadableByteStreamControllerFromUnderlyingSource(
   }
 
   const autoAllocateChunkSize = underlyingByteSource.autoAllocateChunkSize;
+  if (autoAllocateChunkSize === 0) {
+    throw new TypeError('autoAllocateChunkSize must be greater than 0');
+  }
 
   SetUpReadableByteStreamController(
     stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark, autoAllocateChunkSize

--- a/test/run-web-platform-tests.js
+++ b/test/run-web-platform-tests.js
@@ -39,7 +39,9 @@ async function main() {
     // See https://github.com/MattiasBuelens/web-streams-polyfill/issues/3
     'readable-byte-streams/bad-buffers-and-views.any.html',
     // Disable tests for different size functions per realm, since they need a working <iframe>
-    'queuing-strategies-size-function-per-global.window.html'
+    'queuing-strategies-size-function-per-global.window.html',
+    // We don't implement transferable streams yet
+    'transferable/**'
   ];
   const ignoredFailures = {};
 


### PR DESCRIPTION
This aligns the implementation with [spec version `200c971` of 8 February 2021](https://streams.spec.whatwg.org/commit-snapshots/200c971563b1a695fce3eebe6dab45c348ff0ac0/).

Comparison: https://github.com/whatwg/streams/compare/6cd5e81f6191fed9e7d99ee73d4941e3060311ce...200c971563b1a695fce3eebe6dab45c348ff0ac0