### PR TITLE
Improve brand checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 🐛 Make sure streams created with a different version of the polyfill do not pass the brand checks. ([#75](https://github.com/MattiasBuelens/web-streams-polyfill/issues/75), [#77](https://github.com/MattiasBuelens/web-streams-polyfill/pull/77))
+
 ## v3.0.3 (2020-04-09)
 
 * 💅 Change `Promise<void>` to `Promise<undefined>` in TypeScript type definitions ([#72](https://github.com/MattiasBuelens/web-streams-polyfill/pull/72))

--- a/src/lib/byte-length-queuing-strategy.ts
+++ b/src/lib/byte-length-queuing-strategy.ts
@@ -69,5 +69,5 @@ export function IsByteLengthQueuingStrategy(x: any): x is ByteLengthQueuingStrat
     return false;
   }
 
-  return true;
+  return x instanceof ByteLengthQueuingStrategy;
 }

--- a/src/lib/count-queuing-strategy.ts
+++ b/src/lib/count-queuing-strategy.ts
@@ -70,5 +70,5 @@ export function IsCountQueuingStrategy(x: any): x is CountQueuingStrategy {
     return false;
   }
 
-  return true;
+  return x instanceof CountQueuingStrategy;
 }

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -413,7 +413,7 @@ export function IsReadableStream(x: unknown): x is ReadableStream {
     return false;
   }
 
-  return true;
+  return x instanceof ReadableStream;
 }
 
 export function IsReadableStreamDisturbed(stream: ReadableStream): boolean {

--- a/src/lib/readable-stream/async-iterator.ts
+++ b/src/lib/readable-stream/async-iterator.ts
@@ -173,7 +173,12 @@ function IsReadableStreamAsyncIterator<R = any>(x: any): x is ReadableStreamAsyn
     return false;
   }
 
-  return true;
+  try {
+    // noinspection SuspiciousTypeOfGuard
+    return (x as ReadableStreamAsyncIteratorInstance<any>)._asyncIteratorImpl instanceof ReadableStreamAsyncIteratorImpl;
+  } catch {
+    return false;
+  }
 }
 
 // Helper functions for the ReadableStream.

--- a/src/lib/readable-stream/byob-reader.ts
+++ b/src/lib/readable-stream/byob-reader.ts
@@ -237,7 +237,7 @@ export function IsReadableStreamBYOBReader(x: any): x is ReadableStreamBYOBReade
     return false;
   }
 
-  return true;
+  return x instanceof ReadableStreamBYOBReader;
 }
 
 function ReadableStreamBYOBReaderRead<T extends ArrayBufferView>(reader: ReadableStreamBYOBReader,

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -388,7 +388,7 @@ export function IsReadableByteStreamController(x: any): x is ReadableByteStreamC
     return false;
   }
 
-  return true;
+  return x instanceof ReadableByteStreamController;
 }
 
 function IsReadableStreamBYOBRequest(x: any): x is ReadableStreamBYOBRequest {
@@ -400,7 +400,7 @@ function IsReadableStreamBYOBRequest(x: any): x is ReadableStreamBYOBRequest {
     return false;
   }
 
-  return true;
+  return x instanceof ReadableStreamBYOBRequest;
 }
 
 function ReadableByteStreamControllerCallPullIfNeeded(controller: ReadableByteStreamController): void {

--- a/src/lib/readable-stream/default-controller.ts
+++ b/src/lib/readable-stream/default-controller.ts
@@ -156,7 +156,7 @@ function IsReadableStreamDefaultController<R = any>(x: any): x is ReadableStream
     return false;
   }
 
-  return true;
+  return x instanceof ReadableStreamDefaultController;
 }
 
 function ReadableStreamDefaultControllerCallPullIfNeeded(controller: ReadableStreamDefaultController<any>): void {

--- a/src/lib/readable-stream/default-reader.ts
+++ b/src/lib/readable-stream/default-reader.ts
@@ -219,7 +219,7 @@ export function IsReadableStreamDefaultReader<R = any>(x: any): x is ReadableStr
     return false;
   }
 
-  return true;
+  return x instanceof ReadableStreamDefaultReader;
 }
 
 export function ReadableStreamDefaultReaderRead<R>(reader: ReadableStreamDefaultReader<R>,

--- a/src/lib/transform-stream.ts
+++ b/src/lib/transform-stream.ts
@@ -220,7 +220,7 @@ function IsTransformStream(x: unknown): x is TransformStream {
     return false;
   }
 
-  return true;
+  return x instanceof TransformStream;
 }
 
 // This is a no-op if both sides are already errored.
@@ -348,7 +348,7 @@ function IsTransformStreamDefaultController<O = any>(x: any): x is TransformStre
     return false;
   }
 
-  return true;
+  return x instanceof TransformStreamDefaultController;
 }
 
 function SetUpTransformStreamDefaultController<I, O>(stream: TransformStream<I, O>,

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -277,7 +277,7 @@ function IsWritableStream(x: unknown): x is WritableStream {
     return false;
   }
 
-  return true;
+  return x instanceof WritableStream;
 }
 
 function IsWritableStreamLocked(stream: WritableStream): boolean {
@@ -786,7 +786,7 @@ function IsWritableStreamDefaultWriter<W = any>(x: any): x is WritableStreamDefa
     return false;
   }
 
-  return true;
+  return x instanceof WritableStreamDefaultWriter;
 }
 
 // A client of WritableStreamDefaultWriter may use these functions directly to bypass state check.
@@ -997,7 +997,7 @@ function IsWritableStreamDefaultController(x: any): x is WritableStreamDefaultCo
     return false;
   }
 
-  return true;
+  return x instanceof WritableStreamDefaultController;
 }
 
 function SetUpWritableStreamDefaultController<W>(stream: WritableStream<W>,

--- a/test/unit/readable-stream/regression.spec.js
+++ b/test/unit/readable-stream/regression.spec.js
@@ -24,4 +24,33 @@ describe('ReadableStream regressions', () => {
 
     await Promise.all([producer, consumer]);
   });
+
+  // It is not sufficient for our brand checks to check if a (supposedly internal) field exists,
+  // since a stream from a different version of the polyfill would also have such a field.
+  // We must also check if the given stream was constructed with a class from *this* version of the polyfill.
+  // https://github.com/MattiasBuelens/web-streams-polyfill/issues/75
+  // TODO Consider using private symbols or #private fields for brand checks instead? (see #70)
+  describe('issue #75', () => {
+    it('ReadableStream', () => {
+      const fakeReadable = {
+        _readableStreamController: {}
+      };
+      const getReader = ReadableStream.prototype.getReader;
+      expect(() => getReader.call(fakeReadable)).toThrow(jasmine.any(TypeError));
+    });
+    it('WritableStream', () => {
+      const fakeWritable = {
+        _writableStreamController: {}
+      };
+      const getWriter = WritableStream.prototype.getWriter;
+      expect(() => getWriter.call(fakeWritable)).toThrow(jasmine.any(TypeError));
+    });
+    it('TransformStream', () => {
+      const fakeTransformStream = {
+        _transformStreamController: {}
+      };
+      const readableGetter = Object.getOwnPropertyDescriptor(TransformStream.prototype, 'readable');
+      expect(() => readableGetter.call(fakeTransformStream)).toThrow(jasmine.any(TypeError));
+    });
+  });
 });


### PR DESCRIPTION
Make sure streams created with a different version of the polyfill do not pass the brand checks.

Fixes #75.