### PR TITLE
Update to spec version of 15 June 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## Unreleased
 
 * 🐛 Make sure streams created with a different version of the polyfill do not pass the brand checks. ([#75](https://github.com/MattiasBuelens/web-streams-polyfill/issues/75), [#77](https://github.com/MattiasBuelens/web-streams-polyfill/pull/77))
+* 👓 Align with [spec version `c5ca883`](https://github.com/whatwg/streams/tree/c5ca8837c0b50ad1057351a7676824013c36538e/) ([#79](https://github.com/MattiasBuelens/web-streams-polyfill/pull/79))
 
 ## v3.0.3 (2020-04-09)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `polyfill/es2018` and `ponyfill/es2018` variants work in any ES2018-compatib
 
 ### Compliance
 
-The polyfill implements [version `6762cdb` (31 Mar 2021)][spec-snapshot] of the streams specification.
+The polyfill implements [version `c5ca883` (15 Jun 2021)][spec-snapshot] of the streams specification.
 
 The polyfill is tested against the same [web platform tests][wpt] that are used by browsers to test their native implementations.
 The polyfill aims to pass all tests, although it allows some exceptions for practical reasons:
@@ -99,12 +99,12 @@ Thanks to these people for their work on [the original polyfill][creatorrr-polyf
 [promise-support]: https://kangax.github.io/compat-table/es6/#test-Promise
 [promise-polyfill]: https://www.npmjs.com/package/promise-polyfill
 [rs-asynciterator]: https://streams.spec.whatwg.org/#rs-asynciterator
-[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/6762cdb4c6421cfa0da1d834d5a14fdd7326aaa5/
-[wpt]: https://github.com/web-platform-tests/wpt/tree/1bdb43faa7434d36645ab5c64e754b5caefbc9d2/streams
-[wpt-bad-buffers]: https://github.com/web-platform-tests/wpt/blob/1bdb43faa7434d36645ab5c64e754b5caefbc9d2/streams/readable-byte-streams/bad-buffers-and-views.any.js
+[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/c5ca8837c0b50ad1057351a7676824013c36538e/
+[wpt]: https://github.com/web-platform-tests/wpt/tree/b869e60df1b8d3840e09b41c5e987c7e23f6856c/streams
+[wpt-bad-buffers]: https://github.com/web-platform-tests/wpt/blob/b869e60df1b8d3840e09b41c5e987c7e23f6856c/streams/readable-byte-streams/bad-buffers-and-views.any.js
 [proposal-arraybuffer-transfer]: https://github.com/domenic/proposal-arraybuffer-transfer
-[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/6762cdb4c6421cfa0da1d834d5a14fdd7326aaa5/reference-implementation/lib/abstract-ops/ecmascript.js#L16
+[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/c5ca8837c0b50ad1057351a7676824013c36538e/reference-implementation/lib/abstract-ops/ecmascript.js#L16
 [issue-3]: https://github.com/MattiasBuelens/web-streams-polyfill/issues/3
-[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/1bdb43faa7434d36645ab5c64e754b5caefbc9d2/streams/readable-streams/async-iterator.any.js#L24
+[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/b869e60df1b8d3840e09b41c5e987c7e23f6856c/streams/readable-streams/async-iterator.any.js#L24
 [stub-async-iterator-prototype]: https://github.com/MattiasBuelens/web-streams-polyfill/blob/v2.0.0/src/target/es5/stub/async-iterator-prototype.ts
 [creatorrr-polyfill]: https://github.com/creatorrr/web-streams-polyfill

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -86,8 +86,11 @@ export class ReadableStreamBYOBReader {
 
 // @public
 export type ReadableStreamBYOBReadResult<T extends ArrayBufferView> = {
-    done: boolean;
+    done: false;
     value: T;
+} | {
+    done: true;
+    value: T | undefined;
 };
 
 // @public

--- a/src/lib/abstract-ops/ecmascript.ts
+++ b/src/lib/abstract-ops/ecmascript.ts
@@ -18,6 +18,13 @@ export function TransferArrayBuffer<T extends ArrayBufferLike>(O: T): T {
 }
 
 // Not implemented correctly
-export function IsDetachedBuffer(O: ArrayBufferLike): boolean { // eslint-disable-line @typescript-eslint/no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function CanTransferArrayBuffer(O: ArrayBufferLike): boolean {
+  return true;
+}
+
+// Not implemented correctly
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function IsDetachedBuffer(O: ArrayBufferLike): boolean {
   return false;
 }

--- a/src/lib/abstract-ops/miscellaneous.ts
+++ b/src/lib/abstract-ops/miscellaneous.ts
@@ -1,17 +1,5 @@
 import NumberIsNaN from '../../stub/number-isnan';
 
-export function IsFiniteNonNegativeNumber(v: number): boolean {
-  if (!IsNonNegativeNumber(v)) {
-    return false;
-  }
-
-  if (v === Infinity) {
-    return false;
-  }
-
-  return true;
-}
-
 export function IsNonNegativeNumber(v: number): boolean {
   if (typeof v !== 'number') {
     return false;

--- a/src/lib/abstract-ops/queue-with-sizes.ts
+++ b/src/lib/abstract-ops/queue-with-sizes.ts
@@ -1,6 +1,6 @@
 import assert from '../../stub/assert';
 import { SimpleQueue } from '../simple-queue';
-import { IsFiniteNonNegativeNumber } from './miscellaneous';
+import { IsNonNegativeNumber } from './miscellaneous';
 
 export interface QueueContainer<T> {
   _queue: SimpleQueue<T>;
@@ -28,8 +28,7 @@ export function DequeueValue<T>(container: QueueContainer<QueuePair<T>>): T {
 export function EnqueueValueWithSize<T>(container: QueueContainer<QueuePair<T>>, value: T, size: number) {
   assert('_queue' in container && '_queueTotalSize' in container);
 
-  size = Number(size);
-  if (!IsFiniteNonNegativeNumber(size)) {
+  if (!IsNonNegativeNumber(size) || size === Infinity) {
     throw new RangeError('Size must be a finite, non-NaN, non-negative number.');
   }
 

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -375,11 +375,13 @@ export function CreateReadableStream<R>(startAlgorithm: () => void | PromiseLike
 }
 
 // Throws if and only if startAlgorithm throws.
-export function CreateReadableByteStream(startAlgorithm: () => void | PromiseLike<void>,
-                                         pullAlgorithm: () => Promise<void>,
-                                         cancelAlgorithm: (reason: any) => Promise<void>,
-                                         highWaterMark = 0,
-                                         autoAllocateChunkSize: number | undefined = undefined): ReadableStream<Uint8Array> {
+export function CreateReadableByteStream(
+  startAlgorithm: () => void | PromiseLike<void>,
+  pullAlgorithm: () => Promise<void>,
+  cancelAlgorithm: (reason: any) => Promise<void>,
+  highWaterMark = 0,
+  autoAllocateChunkSize: number | undefined = undefined
+): ReadableStream<Uint8Array> {
   assert(IsNonNegativeNumber(highWaterMark));
   if (autoAllocateChunkSize !== undefined) {
     assert(NumberIsInteger(autoAllocateChunkSize));

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -448,6 +448,14 @@ export function ReadableStreamCancel<R>(stream: ReadableStream<R>, reason: any):
 
   ReadableStreamClose(stream);
 
+  const reader = stream._reader;
+  if (reader !== undefined && IsReadableStreamBYOBReader(reader)) {
+    reader._readIntoRequests.forEach(readIntoRequest => {
+      readIntoRequest._closeSteps(undefined);
+    });
+    reader._readIntoRequests = new SimpleQueue();
+  }
+
   const sourceCancelPromise = stream._readableStreamController[CancelSteps](reason);
   return transformPromiseWith(sourceCancelPromise, noop);
 }

--- a/src/lib/readable-stream/async-iterator.ts
+++ b/src/lib/readable-stream/async-iterator.ts
@@ -175,7 +175,8 @@ function IsReadableStreamAsyncIterator<R = any>(x: any): x is ReadableStreamAsyn
 
   try {
     // noinspection SuspiciousTypeOfGuard
-    return (x as ReadableStreamAsyncIteratorInstance<any>)._asyncIteratorImpl instanceof ReadableStreamAsyncIteratorImpl;
+    return (x as ReadableStreamAsyncIteratorInstance<any>)._asyncIteratorImpl instanceof
+      ReadableStreamAsyncIteratorImpl;
   } catch {
     return false;
   }

--- a/src/lib/readable-stream/byob-reader.ts
+++ b/src/lib/readable-stream/byob-reader.ts
@@ -24,8 +24,11 @@ import { IsDetachedBuffer } from '../abstract-ops/ecmascript';
  * @public
  */
 export type ReadableStreamBYOBReadResult<T extends ArrayBufferView> = {
-  done: boolean;
+  done: false;
   value: T;
+} | {
+  done: true;
+  value: T | undefined;
 };
 
 // Abstract operations for the ReadableStream.
@@ -82,7 +85,7 @@ export function ReadableStreamHasBYOBReader(stream: ReadableByteStream): boolean
 export interface ReadIntoRequest<T extends ArrayBufferView> {
   _chunkSteps(chunk: T): void;
 
-  _closeSteps(chunk: T): void;
+  _closeSteps(chunk: T | undefined): void;
 
   _errorSteps(e: any): void;
 }

--- a/src/lib/readable-stream/byob-reader.ts
+++ b/src/lib/readable-stream/byob-reader.ts
@@ -16,6 +16,7 @@ import { typeIsObject } from '../helpers/miscellaneous';
 import { newPromise, promiseRejectedWith } from '../helpers/webidl';
 import { assertRequiredArgument } from '../validators/basic';
 import { assertReadableStream } from '../validators/readable-stream';
+import { IsDetachedBuffer } from '../abstract-ops/ecmascript';
 
 /**
  * A result returned by {@link ReadableStreamBYOBReader.read}.
@@ -166,6 +167,9 @@ export class ReadableStreamBYOBReader {
     }
     if (view.buffer.byteLength === 0) {
       return promiseRejectedWith(new TypeError(`view's buffer must have non-zero byteLength`));
+    }
+    if (IsDetachedBuffer(view.buffer)) {
+      return promiseRejectedWith(new TypeError('view\'s buffer has been detached'));
     }
 
     if (this._ownerReadableStream === undefined) {

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -309,10 +309,7 @@ export class ReadableByteStreamController {
 
   /** @internal */
   [CancelSteps](reason: any): Promise<void> {
-    if (this._pendingPullIntos.length > 0) {
-      const firstDescriptor = this._pendingPullIntos.peek();
-      firstDescriptor.bytesFilled = 0;
-    }
+    ReadableByteStreamControllerClearPendingPullIntos(this);
 
     ResetQueue(this);
 

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -441,8 +441,10 @@ function ReadableByteStreamControllerClearPendingPullIntos(controller: ReadableB
   controller._pendingPullIntos = new SimpleQueue();
 }
 
-function ReadableByteStreamControllerCommitPullIntoDescriptor<T extends ArrayBufferView>(stream: ReadableByteStream,
-                                                                                         pullIntoDescriptor: PullIntoDescriptor<T>) {
+function ReadableByteStreamControllerCommitPullIntoDescriptor<T extends ArrayBufferView>(
+  stream: ReadableByteStream,
+  pullIntoDescriptor: PullIntoDescriptor<T>
+) {
   assert(stream._state !== 'errored');
 
   let done = false;
@@ -460,7 +462,9 @@ function ReadableByteStreamControllerCommitPullIntoDescriptor<T extends ArrayBuf
   }
 }
 
-function ReadableByteStreamControllerConvertPullIntoDescriptor<T extends ArrayBufferView>(pullIntoDescriptor: PullIntoDescriptor<T>): T {
+function ReadableByteStreamControllerConvertPullIntoDescriptor<T extends ArrayBufferView>(
+  pullIntoDescriptor: PullIntoDescriptor<T>
+): T {
   const bytesFilled = pullIntoDescriptor.bytesFilled;
   const elementSize = pullIntoDescriptor.elementSize;
 
@@ -712,7 +716,9 @@ function ReadableByteStreamControllerRespondInternal(controller: ReadableByteStr
   ReadableByteStreamControllerCallPullIfNeeded(controller);
 }
 
-function ReadableByteStreamControllerShiftPendingPullInto(controller: ReadableByteStreamController): PullIntoDescriptor {
+function ReadableByteStreamControllerShiftPendingPullInto(
+  controller: ReadableByteStreamController
+): PullIntoDescriptor {
   const descriptor = controller._pendingPullIntos.shift()!;
   ReadableByteStreamControllerInvalidateBYOBRequest(controller);
   return descriptor;

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -31,7 +31,6 @@ import {
   TransferArrayBuffer
 } from '../abstract-ops/ecmascript';
 import { CancelSteps, PullSteps } from '../abstract-ops/internal-methods';
-import { IsFiniteNonNegativeNumber } from '../abstract-ops/miscellaneous';
 import { promiseResolvedWith, uponPromise } from '../helpers/webidl';
 import { assertRequiredArgument, convertUnsignedLongLongWithEnforceRange } from '../validators/basic';
 
@@ -868,11 +867,6 @@ function ReadableByteStreamControllerGetDesiredSize(controller: ReadableByteStre
 }
 
 function ReadableByteStreamControllerRespond(controller: ReadableByteStreamController, bytesWritten: number) {
-  bytesWritten = Number(bytesWritten);
-  if (!IsFiniteNonNegativeNumber(bytesWritten)) {
-    throw new RangeError('bytesWritten must be a finite');
-  }
-
   assert(controller._pendingPullIntos.length > 0);
 
   const firstDescriptor = controller._pendingPullIntos.peek();

--- a/src/lib/readable-stream/default-controller.ts
+++ b/src/lib/readable-stream/default-controller.ts
@@ -238,7 +238,10 @@ export function ReadableStreamDefaultControllerClose(controller: ReadableStreamD
   }
 }
 
-export function ReadableStreamDefaultControllerEnqueue<R>(controller: ReadableStreamDefaultController<R>, chunk: R): void {
+export function ReadableStreamDefaultControllerEnqueue<R>(
+  controller: ReadableStreamDefaultController<R>,
+  chunk: R
+): void {
   if (!ReadableStreamDefaultControllerCanCloseOrEnqueue(controller)) {
     return;
   }
@@ -280,7 +283,9 @@ export function ReadableStreamDefaultControllerError(controller: ReadableStreamD
   ReadableStreamError(stream, e);
 }
 
-export function ReadableStreamDefaultControllerGetDesiredSize(controller: ReadableStreamDefaultController<any>): number | null {
+export function ReadableStreamDefaultControllerGetDesiredSize(
+  controller: ReadableStreamDefaultController<any>
+): number | null {
   const state = controller._controlledReadableStream._state;
 
   if (state === 'errored') {
@@ -294,7 +299,9 @@ export function ReadableStreamDefaultControllerGetDesiredSize(controller: Readab
 }
 
 // This is used in the implementation of TransformStream.
-export function ReadableStreamDefaultControllerHasBackpressure(controller: ReadableStreamDefaultController<any>): boolean {
+export function ReadableStreamDefaultControllerHasBackpressure(
+  controller: ReadableStreamDefaultController<any>
+): boolean {
   if (ReadableStreamDefaultControllerShouldCallPull(controller)) {
     return false;
   }
@@ -302,7 +309,9 @@ export function ReadableStreamDefaultControllerHasBackpressure(controller: Reada
   return true;
 }
 
-export function ReadableStreamDefaultControllerCanCloseOrEnqueue(controller: ReadableStreamDefaultController<any>): boolean {
+export function ReadableStreamDefaultControllerCanCloseOrEnqueue(
+  controller: ReadableStreamDefaultController<any>
+): boolean {
   const state = controller._controlledReadableStream._state;
 
   if (!controller._closeRequested && state === 'readable') {

--- a/src/lib/readable-stream/underlying-source.ts
+++ b/src/lib/readable-stream/underlying-source.ts
@@ -1,20 +1,28 @@
 import { ReadableStreamDefaultController } from './default-controller';
 import { ReadableByteStreamController } from './byte-stream-controller';
 
-export type ReadableStreamController<R = any> = ReadableStreamDefaultController<R> | ReadableByteStreamController;
-export type UnderlyingDefaultOrByteSourceStartCallback<R> = (controller: ReadableStreamController<R>) => void | PromiseLike<void>;
-export type UnderlyingDefaultOrByteSourcePullCallback<R> = (controller: ReadableStreamController<R>) => void | PromiseLike<void>;
+export type ReadableStreamController<R = any> =
+  ReadableStreamDefaultController<R> | ReadableByteStreamController;
+export type UnderlyingDefaultOrByteSourceStartCallback<R> =
+  (controller: ReadableStreamController<R>) => void | PromiseLike<void>;
+export type UnderlyingDefaultOrByteSourcePullCallback<R> =
+  (controller: ReadableStreamController<R>) => void | PromiseLike<void>;
 
 /** @public */
-export type UnderlyingSourceStartCallback<R> = (controller: ReadableStreamDefaultController<R>) => void | PromiseLike<void>;
+export type UnderlyingSourceStartCallback<R> =
+  (controller: ReadableStreamDefaultController<R>) => void | PromiseLike<void>;
 /** @public */
-export type UnderlyingSourcePullCallback<R> = (controller: ReadableStreamDefaultController<R>) => void | PromiseLike<void>;
+export type UnderlyingSourcePullCallback<R> =
+  (controller: ReadableStreamDefaultController<R>) => void | PromiseLike<void>;
 /** @public */
-export type UnderlyingByteSourceStartCallback = (controller: ReadableByteStreamController) => void | PromiseLike<void>;
+export type UnderlyingByteSourceStartCallback =
+  (controller: ReadableByteStreamController) => void | PromiseLike<void>;
 /** @public */
-export type UnderlyingByteSourcePullCallback = (controller: ReadableByteStreamController) => void | PromiseLike<void>;
+export type UnderlyingByteSourcePullCallback =
+  (controller: ReadableByteStreamController) => void | PromiseLike<void>;
 /** @public */
-export type UnderlyingSourceCancelCallback = (reason: any) => void | PromiseLike<void>;
+export type UnderlyingSourceCancelCallback =
+  (reason: any) => void | PromiseLike<void>;
 
 export type ReadableStreamType = 'bytes';
 

--- a/src/lib/simple-queue.ts
+++ b/src/lib/simple-queue.ts
@@ -129,7 +129,7 @@ export class SimpleQueue<T> {
 
   // Return the element that would be returned if shift() was called now,
   // without modifying the queue.
-  peek() {
+  peek(): T {
     assert(this._size > 0); // must not be called on an empty queue
 
     const front = this._front;

--- a/src/lib/transform-stream.ts
+++ b/src/lib/transform-stream.ts
@@ -225,8 +225,10 @@ function IsTransformStream(x: unknown): x is TransformStream {
 
 // This is a no-op if both sides are already errored.
 function TransformStreamError(stream: TransformStream, e: any) {
-  ReadableStreamDefaultControllerError(stream._readable._readableStreamController as ReadableStreamDefaultController<any>,
-                                       e);
+  ReadableStreamDefaultControllerError(
+    stream._readable._readableStreamController as ReadableStreamDefaultController<any>,
+    e
+  );
   TransformStreamErrorWritableAndUnblockWrite(stream, e);
 }
 

--- a/src/stub/native.ts
+++ b/src/stub/native.ts
@@ -1,2 +1,3 @@
 /// <reference lib="dom" />
-export const NativeDOMException: typeof DOMException | undefined = typeof DOMException !== 'undefined' ? DOMException : undefined;
+export const NativeDOMException: typeof DOMException | undefined =
+  typeof DOMException !== 'undefined' ? DOMException : undefined;

--- a/test/run-web-platform-tests.js
+++ b/test/run-web-platform-tests.js
@@ -38,12 +38,20 @@ async function main() {
     // We cannot polyfill TransferArrayBuffer yet, so disable tests for detached array buffers
     // See https://github.com/MattiasBuelens/web-streams-polyfill/issues/3
     'readable-byte-streams/bad-buffers-and-views.any.html',
+    'readable-byte-streams/enqueue-with-detached-buffer.window.html',
+    'readable-byte-streams/non-transferable-buffers.any.html',
     // Disable tests for different size functions per realm, since they need a working <iframe>
     'queuing-strategies-size-function-per-global.window.html',
     // We don't implement transferable streams yet
     'transferable/**'
   ];
-  const ignoredFailures = {};
+  const ignoredFailures = {
+    // We cannot transfer byobRequest.view.buffer after respond() or enqueue()
+    'readable-byte-streams/general.any.html': [
+      'ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple respond() calls',
+      'ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple enqueue() calls'
+    ]
+  };
 
   const ignoredFailuresMinified = {
     'idlharness.any.html': [


### PR DESCRIPTION
This aligns the implementation with [spec version `c5ca883` of 15 June 2021](https://streams.spec.whatwg.org/commit-snapshots/c5ca8837c0b50ad1057351a7676824013c36538e/).

Comparison: https://github.com/whatwg/streams/compare/6762cdb4c6421cfa0da1d834d5a14fdd7326aaa5...c5ca8837c0b50ad1057351a7676824013c36538e