### PR TITLE
Update to spec version of 8 July 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@
 
 ## Unreleased
 
+* 🚀 `ReadableStream.tee()` on a readable byte stream now returns two readable byte streams. ([#81](https://github.com/MattiasBuelens/web-streams-polyfill/pull/81))
+* 🚀 Add `WritableStreamDefaultController.signal` and `.abortReason`. ([#81](https://github.com/MattiasBuelens/web-streams-polyfill/pull/81))
 * 🐛 Make sure streams created with a different version of the polyfill do not pass the brand checks. ([#75](https://github.com/MattiasBuelens/web-streams-polyfill/issues/75), [#77](https://github.com/MattiasBuelens/web-streams-polyfill/pull/77))
-* 👓 Align with [spec version `c5ca883`](https://github.com/whatwg/streams/tree/c5ca8837c0b50ad1057351a7676824013c36538e/) ([#79](https://github.com/MattiasBuelens/web-streams-polyfill/pull/79))
+* 👓 Align with [spec version `cada812`](https://github.com/whatwg/streams/tree/cada8129edcc4803b2878a7a3f5e1d8325dc0c23/) ([#79](https://github.com/MattiasBuelens/web-streams-polyfill/pull/79), [#81](https://github.com/MattiasBuelens/web-streams-polyfill/pull/81))
 
 ## v3.0.3 (2020-04-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * 🚀 Calling `ReadableStream.tee()` on a readable byte stream now returns two readable byte streams. ([#81](https://github.com/MattiasBuelens/web-streams-polyfill/pull/81))
 * 🚀 Add `WritableStreamDefaultController.signal` and `.abortReason`. ([#81](https://github.com/MattiasBuelens/web-streams-polyfill/pull/81))
+  * `.signal` requires a global `AbortController` constructor to be available. If necessary, use a polyfill.
 * 🐛 Make sure streams created with a different version of the polyfill do not pass the brand checks. ([#75](https://github.com/MattiasBuelens/web-streams-polyfill/issues/75), [#77](https://github.com/MattiasBuelens/web-streams-polyfill/pull/77))
 * 👓 Align with [spec version `cada812`](https://github.com/whatwg/streams/tree/cada8129edcc4803b2878a7a3f5e1d8325dc0c23/) ([#79](https://github.com/MattiasBuelens/web-streams-polyfill/pull/79), [#81](https://github.com/MattiasBuelens/web-streams-polyfill/pull/81))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ## Unreleased
 
-* 🚀 `ReadableStream.tee()` on a readable byte stream now returns two readable byte streams. ([#81](https://github.com/MattiasBuelens/web-streams-polyfill/pull/81))
+* 🚀 Calling `ReadableStream.tee()` on a readable byte stream now returns two readable byte streams. ([#81](https://github.com/MattiasBuelens/web-streams-polyfill/pull/81))
 * 🚀 Add `WritableStreamDefaultController.signal` and `.abortReason`. ([#81](https://github.com/MattiasBuelens/web-streams-polyfill/pull/81))
 * 🐛 Make sure streams created with a different version of the polyfill do not pass the brand checks. ([#75](https://github.com/MattiasBuelens/web-streams-polyfill/issues/75), [#77](https://github.com/MattiasBuelens/web-streams-polyfill/pull/77))
 * 👓 Align with [spec version `cada812`](https://github.com/whatwg/streams/tree/cada8129edcc4803b2878a7a3f5e1d8325dc0c23/) ([#79](https://github.com/MattiasBuelens/web-streams-polyfill/pull/79), [#81](https://github.com/MattiasBuelens/web-streams-polyfill/pull/81))

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The `polyfill/es2018` and `ponyfill/es2018` variants work in any ES2018-compatib
 
 ### Compliance
 
-The polyfill implements [version `c5ca883` (15 Jun 2021)][spec-snapshot] of the streams specification.
+The polyfill implements [version `cada812` (8 Jul 2021)][spec-snapshot] of the streams specification.
 
 The polyfill is tested against the same [web platform tests][wpt] that are used by browsers to test their native implementations.
 The polyfill aims to pass all tests, although it allows some exceptions for practical reasons:
@@ -99,12 +99,12 @@ Thanks to these people for their work on [the original polyfill][creatorrr-polyf
 [promise-support]: https://kangax.github.io/compat-table/es6/#test-Promise
 [promise-polyfill]: https://www.npmjs.com/package/promise-polyfill
 [rs-asynciterator]: https://streams.spec.whatwg.org/#rs-asynciterator
-[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/c5ca8837c0b50ad1057351a7676824013c36538e/
-[wpt]: https://github.com/web-platform-tests/wpt/tree/b869e60df1b8d3840e09b41c5e987c7e23f6856c/streams
-[wpt-bad-buffers]: https://github.com/web-platform-tests/wpt/blob/b869e60df1b8d3840e09b41c5e987c7e23f6856c/streams/readable-byte-streams/bad-buffers-and-views.any.js
+[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/cada8129edcc4803b2878a7a3f5e1d8325dc0c23/
+[wpt]: https://github.com/web-platform-tests/wpt/tree/87a4c80598aee5178c385628174f1832f5a28ad6/streams
+[wpt-bad-buffers]: https://github.com/web-platform-tests/wpt/blob/87a4c80598aee5178c385628174f1832f5a28ad6/streams/readable-byte-streams/bad-buffers-and-views.any.js
 [proposal-arraybuffer-transfer]: https://github.com/domenic/proposal-arraybuffer-transfer
-[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/c5ca8837c0b50ad1057351a7676824013c36538e/reference-implementation/lib/abstract-ops/ecmascript.js#L16
+[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/cada8129edcc4803b2878a7a3f5e1d8325dc0c23/reference-implementation/lib/abstract-ops/ecmascript.js#L16
 [issue-3]: https://github.com/MattiasBuelens/web-streams-polyfill/issues/3
-[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/b869e60df1b8d3840e09b41c5e987c7e23f6856c/streams/readable-streams/async-iterator.any.js#L24
+[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/87a4c80598aee5178c385628174f1832f5a28ad6/streams/readable-streams/async-iterator.any.js#L24
 [stub-async-iterator-prototype]: https://github.com/MattiasBuelens/web-streams-polyfill/blob/v2.0.0/src/target/es5/stub/async-iterator-prototype.ts
 [creatorrr-polyfill]: https://github.com/creatorrr/web-streams-polyfill

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The `polyfill/es2018` and `ponyfill/es2018` variants work in any ES2018-compatib
 
 [Async iterable support for `ReadableStream`][rs-asynciterator] is available in all variants, but requires an ES2018-compatible environment or a polyfill for `Symbol.asyncIterator`.
 
+[`WritableStreamDefaultController.signal`][ws-controller-signal] is available in all variants, but requires a global `AbortController` constructor. If necessary, consider using a polyfill such as [abortcontroller-polyfill].
+
 ### Compliance
 
 The polyfill implements [version `cada812` (8 Jul 2021)][spec-snapshot] of the streams specification.
@@ -99,6 +101,8 @@ Thanks to these people for their work on [the original polyfill][creatorrr-polyf
 [promise-support]: https://kangax.github.io/compat-table/es6/#test-Promise
 [promise-polyfill]: https://www.npmjs.com/package/promise-polyfill
 [rs-asynciterator]: https://streams.spec.whatwg.org/#rs-asynciterator
+[ws-controller-signal]: https://streams.spec.whatwg.org/#ws-default-controller-signal
+[abortcontroller-polyfill]: https://www.npmjs.com/package/abortcontroller-polyfill
 [spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/cada8129edcc4803b2878a7a3f5e1d8325dc0c23/
 [wpt]: https://github.com/web-platform-tests/wpt/tree/87a4c80598aee5178c385628174f1832f5a28ad6/streams
 [wpt-bad-buffers]: https://github.com/web-platform-tests/wpt/blob/87a4c80598aee5178c385628174f1832f5a28ad6/streams/readable-byte-streams/bad-buffers-and-views.any.js

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -249,7 +249,9 @@ export class WritableStream<W = any> {
 
 // @public
 export class WritableStreamDefaultController<W = any> {
+    get abortReason(): any;
     error(e?: any): void;
+    get signal(): AbortSignal;
 }
 
 // @public

--- a/src/lib/abort-signal.ts
+++ b/src/lib/abort-signal.ts
@@ -37,3 +37,37 @@ export function isAbortSignal(value: unknown): value is AbortSignal {
     return false;
   }
 }
+
+/**
+ * A controller object that allows you to abort an `AbortSignal` when desired.
+ *
+ * @remarks
+ *   This interface is compatible with the `AbortController` interface defined in TypeScript's DOM types.
+ *   It is redefined here, so it can be polyfilled without a DOM, for example with
+ *   {@link https://www.npmjs.com/package/abortcontroller-polyfill | abortcontroller-polyfill} in a Node environment.
+ *
+ * @internal
+ */
+export interface AbortController {
+  readonly signal: AbortSignal;
+
+  abort(): void;
+}
+
+interface AbortControllerConstructor {
+  new(): AbortController;
+}
+
+const supportsAbortController = typeof (AbortController as any) === 'function';
+
+/**
+ * Construct a new AbortController, if supported by the platform.
+ *
+ * @internal
+ */
+export function createAbortController(): AbortController | undefined {
+  if (supportsAbortController) {
+    return new (AbortController as AbortControllerConstructor)();
+  }
+  return undefined;
+}

--- a/src/lib/abstract-ops/ecmascript.ts
+++ b/src/lib/abstract-ops/ecmascript.ts
@@ -28,3 +28,15 @@ export function CanTransferArrayBuffer(O: ArrayBufferLike): boolean {
 export function IsDetachedBuffer(O: ArrayBufferLike): boolean {
   return false;
 }
+
+export function ArrayBufferSlice(buffer: ArrayBufferLike, begin: number, end: number): ArrayBufferLike {
+  // ArrayBuffer.prototype.slice is not available on IE10
+  // https://www.caniuse.com/mdn-javascript_builtins_arraybuffer_slice
+  if (buffer.slice) {
+    return buffer.slice(begin, end);
+  }
+  const length = end - begin;
+  const slice = new ArrayBuffer(length);
+  CopyDataBlockBytes(slice, 0, buffer, begin, length);
+  return slice;
+}

--- a/src/lib/abstract-ops/miscellaneous.ts
+++ b/src/lib/abstract-ops/miscellaneous.ts
@@ -1,4 +1,5 @@
 import NumberIsNaN from '../../stub/number-isnan';
+import { ArrayBufferSlice } from './ecmascript';
 
 export function IsNonNegativeNumber(v: number): boolean {
   if (typeof v !== 'number') {
@@ -17,6 +18,6 @@ export function IsNonNegativeNumber(v: number): boolean {
 }
 
 export function CloneAsUint8Array(O: ArrayBufferView): Uint8Array {
-  const buffer = O.buffer.slice(O.byteOffset, O.byteOffset + O.byteLength);
+  const buffer = ArrayBufferSlice(O.buffer, O.byteOffset, O.byteOffset + O.byteLength);
   return new Uint8Array(buffer);
 }

--- a/src/lib/abstract-ops/miscellaneous.ts
+++ b/src/lib/abstract-ops/miscellaneous.ts
@@ -15,3 +15,8 @@ export function IsNonNegativeNumber(v: number): boolean {
 
   return true;
 }
+
+export function CloneAsUint8Array(O: ArrayBufferView): Uint8Array {
+  const buffer = O.buffer.slice(O.byteOffset, O.byteOffset + O.byteLength);
+  return new Uint8Array(buffer);
+}

--- a/src/lib/byte-length-queuing-strategy.ts
+++ b/src/lib/byte-length-queuing-strategy.ts
@@ -3,9 +3,14 @@ import { typeIsObject } from './helpers/miscellaneous';
 import { assertRequiredArgument } from './validators/basic';
 import { convertQueuingStrategyInit } from './validators/queuing-strategy-init';
 
-const byteLengthSizeFunction = function size(chunk: ArrayBufferView): number {
+// The size function must not have a prototype property nor be a constructor
+const byteLengthSizeFunction = (chunk: ArrayBufferView): number => {
   return chunk.byteLength;
 };
+Object.defineProperty(byteLengthSizeFunction, 'name', {
+  value: 'size',
+  configurable: true
+});
 
 /**
  * A queuing strategy that counts the number of bytes in each chunk.

--- a/src/lib/count-queuing-strategy.ts
+++ b/src/lib/count-queuing-strategy.ts
@@ -3,9 +3,14 @@ import { typeIsObject } from './helpers/miscellaneous';
 import { assertRequiredArgument } from './validators/basic';
 import { convertQueuingStrategyInit } from './validators/queuing-strategy-init';
 
-const countSizeFunction = function size(): 1 {
+// The size function must not have a prototype property nor be a constructor
+const countSizeFunction = (): 1 => {
   return 1;
 };
+Object.defineProperty(countSizeFunction, 'name', {
+  value: 'size',
+  configurable: true
+});
 
 /**
  * A queuing strategy that counts the number of chunks.

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -23,7 +23,6 @@ import {
 import { ReadableStreamPipeTo } from './readable-stream/pipe';
 import { ReadableStreamTee } from './readable-stream/tee';
 import { IsWritableStream, IsWritableStreamLocked, WritableStream } from './writable-stream';
-import NumberIsInteger from '../stub/number-isinteger';
 import { SimpleQueue } from './simple-queue';
 import {
   ReadableByteStreamController,
@@ -380,23 +379,13 @@ export function CreateReadableStream<R>(startAlgorithm: () => void | PromiseLike
 export function CreateReadableByteStream(
   startAlgorithm: () => void | PromiseLike<void>,
   pullAlgorithm: () => Promise<void>,
-  cancelAlgorithm: (reason: any) => Promise<void>,
-  highWaterMark = 0,
-  autoAllocateChunkSize: number | undefined = undefined
+  cancelAlgorithm: (reason: any) => Promise<void>
 ): ReadableByteStream {
-  assert(IsNonNegativeNumber(highWaterMark));
-  if (autoAllocateChunkSize !== undefined) {
-    assert(NumberIsInteger(autoAllocateChunkSize));
-    assert(autoAllocateChunkSize > 0);
-  }
-
-  const stream: ReadableStream<Uint8Array> = Object.create(ReadableStream.prototype);
+  const stream: ReadableByteStream = Object.create(ReadableStream.prototype);
   InitializeReadableStream(stream);
 
   const controller: ReadableByteStreamController = Object.create(ReadableByteStreamController.prototype);
-
-  SetUpReadableByteStreamController(stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, highWaterMark,
-                                    autoAllocateChunkSize);
+  SetUpReadableByteStreamController(stream, controller, startAlgorithm, pullAlgorithm, cancelAlgorithm, 0, undefined);
 
   return stream;
 }

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -63,7 +63,9 @@ import { convertPipeOptions } from './validators/pipe-options';
 import { ReadableWritablePair } from './readable-stream/readable-writable-pair';
 import { convertReadableWritablePair } from './validators/readable-writable-pair';
 
-export type ReadableByteStream = ReadableStream<Uint8Array>;
+export type ReadableByteStream = ReadableStream<Uint8Array> & {
+  _readableStreamController: ReadableByteStreamController
+};
 
 type ReadableStreamState = 'readable' | 'closed' | 'errored';
 
@@ -381,7 +383,7 @@ export function CreateReadableByteStream(
   cancelAlgorithm: (reason: any) => Promise<void>,
   highWaterMark = 0,
   autoAllocateChunkSize: number | undefined = undefined
-): ReadableStream<Uint8Array> {
+): ReadableByteStream {
   assert(IsNonNegativeNumber(highWaterMark));
   if (autoAllocateChunkSize !== undefined) {
     assert(NumberIsInteger(autoAllocateChunkSize));

--- a/src/lib/readable-stream/byob-reader.ts
+++ b/src/lib/readable-stream/byob-reader.ts
@@ -247,9 +247,11 @@ export function IsReadableStreamBYOBReader(x: any): x is ReadableStreamBYOBReade
   return x instanceof ReadableStreamBYOBReader;
 }
 
-function ReadableStreamBYOBReaderRead<T extends ArrayBufferView>(reader: ReadableStreamBYOBReader,
-                                                                 view: T,
-                                                                 readIntoRequest: ReadIntoRequest<T>): void {
+export function ReadableStreamBYOBReaderRead<T extends ArrayBufferView>(
+  reader: ReadableStreamBYOBReader,
+  view: T,
+  readIntoRequest: ReadIntoRequest<T>
+): void {
   const stream = reader._ownerReadableStream;
 
   assert(stream !== undefined);

--- a/src/lib/readable-stream/byob-reader.ts
+++ b/src/lib/readable-stream/byob-reader.ts
@@ -33,7 +33,7 @@ export type ReadableStreamBYOBReadResult<T extends ArrayBufferView> = {
 
 // Abstract operations for the ReadableStream.
 
-export function AcquireReadableStreamBYOBReader(stream: ReadableStream<Uint8Array>): ReadableStreamBYOBReader {
+export function AcquireReadableStreamBYOBReader(stream: ReadableByteStream): ReadableStreamBYOBReader {
   return new ReadableStreamBYOBReader(stream);
 }
 

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -215,18 +215,7 @@ export class ReadableByteStreamController {
       throw byteStreamControllerBrandCheckException('byobRequest');
     }
 
-    if (this._byobRequest === null && this._pendingPullIntos.length > 0) {
-      const firstDescriptor = this._pendingPullIntos.peek();
-      const view = new Uint8Array(firstDescriptor.buffer,
-                                  firstDescriptor.byteOffset + firstDescriptor.bytesFilled,
-                                  firstDescriptor.byteLength - firstDescriptor.bytesFilled);
-
-      const byobRequest: ReadableStreamBYOBRequest = Object.create(ReadableStreamBYOBRequest.prototype);
-      SetUpReadableStreamBYOBRequest(byobRequest, this, view);
-      this._byobRequest = byobRequest;
-    }
-
-    return this._byobRequest;
+    return ReadableByteStreamControllerGetBYOBRequest(this);
   }
 
   /**
@@ -764,7 +753,7 @@ function ReadableByteStreamControllerClearAlgorithms(controller: ReadableByteStr
 
 // A client of ReadableByteStreamController may use these functions directly to bypass state check.
 
-function ReadableByteStreamControllerClose(controller: ReadableByteStreamController) {
+export function ReadableByteStreamControllerClose(controller: ReadableByteStreamController) {
   const stream = controller._controlledReadableByteStream;
 
   if (controller._closeRequested || stream._state !== 'readable') {
@@ -791,7 +780,7 @@ function ReadableByteStreamControllerClose(controller: ReadableByteStreamControl
   ReadableStreamClose(stream);
 }
 
-function ReadableByteStreamControllerEnqueue(controller: ReadableByteStreamController, chunk: ArrayBufferView) {
+export function ReadableByteStreamControllerEnqueue(controller: ReadableByteStreamController, chunk: ArrayBufferView) {
   const stream = controller._controlledReadableByteStream;
 
   if (controller._closeRequested || stream._state !== 'readable') {
@@ -839,7 +828,7 @@ function ReadableByteStreamControllerEnqueue(controller: ReadableByteStreamContr
   ReadableByteStreamControllerCallPullIfNeeded(controller);
 }
 
-function ReadableByteStreamControllerError(controller: ReadableByteStreamController, e: any) {
+export function ReadableByteStreamControllerError(controller: ReadableByteStreamController, e: any) {
   const stream = controller._controlledReadableByteStream;
 
   if (stream._state !== 'readable') {
@@ -851,6 +840,22 @@ function ReadableByteStreamControllerError(controller: ReadableByteStreamControl
   ResetQueue(controller);
   ReadableByteStreamControllerClearAlgorithms(controller);
   ReadableStreamError(stream, e);
+}
+
+export function ReadableByteStreamControllerGetBYOBRequest(
+  controller: ReadableByteStreamController
+): ReadableStreamBYOBRequest | null {
+  if (controller._byobRequest === null && controller._pendingPullIntos.length > 0) {
+    const firstDescriptor = controller._pendingPullIntos.peek();
+    const view = new Uint8Array(firstDescriptor.buffer,
+                                firstDescriptor.byteOffset + firstDescriptor.bytesFilled,
+                                firstDescriptor.byteLength - firstDescriptor.bytesFilled);
+
+    const byobRequest: ReadableStreamBYOBRequest = Object.create(ReadableStreamBYOBRequest.prototype);
+    SetUpReadableStreamBYOBRequest(byobRequest, controller, view);
+    controller._byobRequest = byobRequest;
+  }
+  return controller._byobRequest;
 }
 
 function ReadableByteStreamControllerGetDesiredSize(controller: ReadableByteStreamController): number | null {
@@ -866,7 +871,7 @@ function ReadableByteStreamControllerGetDesiredSize(controller: ReadableByteStre
   return controller._strategyHWM - controller._queueTotalSize;
 }
 
-function ReadableByteStreamControllerRespond(controller: ReadableByteStreamController, bytesWritten: number) {
+export function ReadableByteStreamControllerRespond(controller: ReadableByteStreamController, bytesWritten: number) {
   assert(controller._pendingPullIntos.length > 0);
 
   const firstDescriptor = controller._pendingPullIntos.peek();
@@ -891,8 +896,8 @@ function ReadableByteStreamControllerRespond(controller: ReadableByteStreamContr
   ReadableByteStreamControllerRespondInternal(controller, bytesWritten);
 }
 
-function ReadableByteStreamControllerRespondWithNewView(controller: ReadableByteStreamController,
-                                                        view: ArrayBufferView) {
+export function ReadableByteStreamControllerRespondWithNewView(controller: ReadableByteStreamController,
+                                                               view: ArrayBufferView) {
   assert(controller._pendingPullIntos.length > 0);
   assert(!IsDetachedBuffer(view.buffer));
 

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -25,6 +25,7 @@ import {
 import { ValidatedUnderlyingByteSource } from './underlying-source';
 import { typeIsObject } from '../helpers/miscellaneous';
 import {
+  ArrayBufferSlice,
   CanTransferArrayBuffer,
   CopyDataBlockBytes,
   IsDetachedBuffer,
@@ -677,7 +678,7 @@ function ReadableByteStreamControllerRespondInReadableState(controller: Readable
   const remainderSize = pullIntoDescriptor.bytesFilled % pullIntoDescriptor.elementSize;
   if (remainderSize > 0) {
     const end = pullIntoDescriptor.byteOffset + pullIntoDescriptor.bytesFilled;
-    const remainder = pullIntoDescriptor.buffer.slice(end - remainderSize, end);
+    const remainder = ArrayBufferSlice(pullIntoDescriptor.buffer, end - remainderSize, end);
     ReadableByteStreamControllerEnqueueChunkToQueue(controller, remainder, 0, remainder.byteLength);
   }
 

--- a/src/lib/readable-stream/tee.ts
+++ b/src/lib/readable-stream/tee.ts
@@ -1,5 +1,25 @@
-import { CreateReadableStream, IsReadableStream, ReadableStream, ReadableStreamCancel } from '../readable-stream';
-import { AcquireReadableStreamDefaultReader, ReadableStreamDefaultReaderRead, ReadRequest } from './default-reader';
+import {
+  CreateReadableByteStream,
+  CreateReadableStream,
+  IsReadableStream,
+  ReadableByteStream,
+  ReadableStream,
+  ReadableStreamCancel,
+  ReadableStreamReader
+} from '../readable-stream';
+import { ReadableStreamReaderGenericRelease } from './generic-reader';
+import {
+  AcquireReadableStreamDefaultReader,
+  IsReadableStreamDefaultReader,
+  ReadableStreamDefaultReaderRead,
+  ReadRequest
+} from './default-reader';
+import {
+  AcquireReadableStreamBYOBReader,
+  IsReadableStreamBYOBReader,
+  ReadableStreamBYOBReaderRead,
+  ReadIntoRequest
+} from './byob-reader';
 import assert from '../../stub/assert';
 import { newPromise, promiseResolvedWith, queueMicrotask, uponRejection } from '../helpers/webidl';
 import {
@@ -8,10 +28,31 @@ import {
   ReadableStreamDefaultControllerEnqueue,
   ReadableStreamDefaultControllerError
 } from './default-controller';
+import {
+  IsReadableByteStreamController,
+  ReadableByteStreamControllerClose,
+  ReadableByteStreamControllerEnqueue,
+  ReadableByteStreamControllerError,
+  ReadableByteStreamControllerGetBYOBRequest,
+  ReadableByteStreamControllerRespond,
+  ReadableByteStreamControllerRespondWithNewView
+} from './byte-stream-controller';
 import { CreateArrayFromList } from '../abstract-ops/ecmascript';
+import { CloneAsUint8Array } from '../abstract-ops/miscellaneous';
 
 export function ReadableStreamTee<R>(stream: ReadableStream<R>,
                                      cloneForBranch2: boolean): [ReadableStream<R>, ReadableStream<R>] {
+  assert(IsReadableStream(stream));
+  assert(typeof cloneForBranch2 === 'boolean');
+  if (IsReadableByteStreamController(stream._readableStreamController)) {
+    return ReadableByteStreamTee(stream as unknown as ReadableByteStream) as
+      unknown as [ReadableStream<R>, ReadableStream<R>];
+  }
+  return ReadableStreamDefaultTee(stream, cloneForBranch2);
+}
+
+export function ReadableStreamDefaultTee<R>(stream: ReadableStream<R>,
+                                            cloneForBranch2: boolean): [ReadableStream<R>, ReadableStream<R>] {
   assert(IsReadableStream(stream));
   assert(typeof cloneForBranch2 === 'boolean');
 
@@ -25,8 +66,8 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
   let branch1: ReadableStream<R>;
   let branch2: ReadableStream<R>;
 
-  let resolveCancelPromise: (reason: any) => void;
-  const cancelPromise = newPromise<any>(resolve => {
+  let resolveCancelPromise: (value: undefined | Promise<undefined>) => void;
+  const cancelPromise = newPromise<undefined>(resolve => {
     resolveCancelPromise = resolve;
   });
 
@@ -38,32 +79,32 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
     reading = true;
 
     const readRequest: ReadRequest<R> = {
-      _chunkSteps: value => {
+      _chunkSteps: chunk => {
         // This needs to be delayed a microtask because it takes at least a microtask to detect errors (using
         // reader._closedPromise below), and we want errors in stream to error both branches immediately. We cannot let
         // successful synchronously-available reads get ahead of asynchronously-available errors.
         queueMicrotask(() => {
           reading = false;
-          const value1 = value;
-          const value2 = value;
+          const chunk1 = chunk;
+          const chunk2 = chunk;
 
           // There is no way to access the cloning code right now in the reference implementation.
           // If we add one then we'll need an implementation for serializable objects.
           // if (!canceled2 && cloneForBranch2) {
-          //   value2 = StructuredDeserialize(StructuredSerialize(value2));
+          //   chunk2 = StructuredDeserialize(StructuredSerialize(chunk2));
           // }
 
           if (!canceled1) {
             ReadableStreamDefaultControllerEnqueue(
               branch1._readableStreamController as ReadableStreamDefaultController<R>,
-              value1
+              chunk1
             );
           }
 
           if (!canceled2) {
             ReadableStreamDefaultControllerEnqueue(
               branch2._readableStreamController as ReadableStreamDefaultController<R>,
-              value2
+              chunk2
             );
           }
         });
@@ -126,6 +167,245 @@ export function ReadableStreamTee<R>(stream: ReadableStream<R>,
       resolveCancelPromise(undefined);
     }
   });
+
+  return [branch1, branch2];
+}
+
+export function ReadableByteStreamTee(stream: ReadableByteStream): [ReadableByteStream, ReadableByteStream] {
+  assert(IsReadableStream(stream));
+  assert(IsReadableByteStreamController(stream._readableStreamController));
+
+  let reader: ReadableStreamReader<Uint8Array> = AcquireReadableStreamDefaultReader(stream);
+  let reading = false;
+  let canceled1 = false;
+  let canceled2 = false;
+  let reason1: any;
+  let reason2: any;
+  let branch1: ReadableByteStream;
+  let branch2: ReadableByteStream;
+
+  let resolveCancelPromise: (value: undefined | Promise<undefined>) => void;
+  const cancelPromise = newPromise<void>(resolve => {
+    resolveCancelPromise = resolve;
+  });
+
+  function forwardReaderError(thisReader: ReadableStreamReader<Uint8Array>) {
+    uponRejection(thisReader._closedPromise, r => {
+      if (thisReader !== reader) {
+        return;
+      }
+      ReadableByteStreamControllerError(branch1._readableStreamController, r);
+      ReadableByteStreamControllerError(branch2._readableStreamController, r);
+      if (!canceled1 || !canceled2) {
+        resolveCancelPromise(undefined);
+      }
+    });
+  }
+
+  function pullWithDefaultReader() {
+    if (IsReadableStreamBYOBReader(reader)) {
+      assert(reader._readIntoRequests.length === 0);
+      ReadableStreamReaderGenericRelease(reader);
+
+      reader = AcquireReadableStreamDefaultReader(stream);
+      forwardReaderError(reader);
+    }
+
+    const readRequest: ReadRequest<Uint8Array> = {
+      _chunkSteps: chunk => {
+        // This needs to be delayed a microtask because it takes at least a microtask to detect errors (using
+        // reader._closedPromise below), and we want errors in stream to error both branches immediately. We cannot let
+        // successful synchronously-available reads get ahead of asynchronously-available errors.
+        queueMicrotask(() => {
+          reading = false;
+
+          const chunk1 = chunk;
+          let chunk2 = chunk;
+          if (!canceled1 && !canceled2) {
+            try {
+              chunk2 = CloneAsUint8Array(chunk);
+            } catch (cloneE) {
+              ReadableByteStreamControllerError(branch1._readableStreamController, cloneE);
+              ReadableByteStreamControllerError(branch2._readableStreamController, cloneE);
+              resolveCancelPromise(ReadableStreamCancel(stream, cloneE));
+              return;
+            }
+          }
+
+          if (!canceled1) {
+            ReadableByteStreamControllerEnqueue(branch1._readableStreamController, chunk1);
+          }
+          if (!canceled2) {
+            ReadableByteStreamControllerEnqueue(branch2._readableStreamController, chunk2);
+          }
+        });
+      },
+      _closeSteps: () => {
+        reading = false;
+        if (!canceled1) {
+          ReadableByteStreamControllerClose(branch1._readableStreamController);
+        }
+        if (!canceled2) {
+          ReadableByteStreamControllerClose(branch2._readableStreamController);
+        }
+        if (branch1._readableStreamController._pendingPullIntos.length > 0) {
+          ReadableByteStreamControllerRespond(branch1._readableStreamController, 0);
+        }
+        if (branch2._readableStreamController._pendingPullIntos.length > 0) {
+          ReadableByteStreamControllerRespond(branch2._readableStreamController, 0);
+        }
+        if (!canceled1 || !canceled2) {
+          resolveCancelPromise(undefined);
+        }
+      },
+      _errorSteps: () => {
+        reading = false;
+      }
+    };
+    ReadableStreamDefaultReaderRead(reader, readRequest);
+  }
+
+  function pullWithBYOBReader(view: ArrayBufferView, forBranch2: boolean) {
+    if (IsReadableStreamDefaultReader<Uint8Array>(reader)) {
+      assert(reader._readRequests.length === 0);
+      ReadableStreamReaderGenericRelease(reader);
+
+      reader = AcquireReadableStreamBYOBReader(stream);
+      forwardReaderError(reader);
+    }
+
+    const byobBranch = forBranch2 ? branch2 : branch1;
+    const otherBranch = forBranch2 ? branch1 : branch2;
+
+    const readIntoRequest: ReadIntoRequest<ArrayBufferView> = {
+      _chunkSteps: chunk => {
+        // This needs to be delayed a microtask because it takes at least a microtask to detect errors (using
+        // reader._closedPromise below), and we want errors in stream to error both branches immediately. We cannot let
+        // successful synchronously-available reads get ahead of asynchronously-available errors.
+        queueMicrotask(() => {
+          reading = false;
+
+          const byobCanceled = forBranch2 ? canceled2 : canceled1;
+          const otherCanceled = forBranch2 ? canceled1 : canceled2;
+
+          if (!otherCanceled) {
+            let clonedChunk;
+            try {
+              clonedChunk = CloneAsUint8Array(chunk);
+            } catch (cloneE) {
+              ReadableByteStreamControllerError(byobBranch._readableStreamController, cloneE);
+              ReadableByteStreamControllerError(otherBranch._readableStreamController, cloneE);
+              resolveCancelPromise(ReadableStreamCancel(stream, cloneE));
+              return;
+            }
+            if (!byobCanceled) {
+              ReadableByteStreamControllerRespondWithNewView(byobBranch._readableStreamController, chunk);
+            }
+            ReadableByteStreamControllerEnqueue(otherBranch._readableStreamController, clonedChunk);
+          } else if (!byobCanceled) {
+            ReadableByteStreamControllerRespondWithNewView(byobBranch._readableStreamController, chunk);
+          }
+        });
+      },
+      _closeSteps: chunk => {
+        reading = false;
+
+        const byobCanceled = forBranch2 ? canceled2 : canceled1;
+        const otherCanceled = forBranch2 ? canceled1 : canceled2;
+
+        if (!byobCanceled) {
+          ReadableByteStreamControllerClose(byobBranch._readableStreamController);
+        }
+        if (!otherCanceled) {
+          ReadableByteStreamControllerClose(otherBranch._readableStreamController);
+        }
+
+        if (chunk !== undefined) {
+          assert(chunk.byteLength === 0);
+
+          if (!byobCanceled) {
+            ReadableByteStreamControllerRespondWithNewView(byobBranch._readableStreamController, chunk);
+          }
+          if (!otherCanceled && otherBranch._readableStreamController._pendingPullIntos.length > 0) {
+            ReadableByteStreamControllerRespond(otherBranch._readableStreamController, 0);
+          }
+        }
+
+        if (!byobCanceled || !otherCanceled) {
+          resolveCancelPromise(undefined);
+        }
+      },
+      _errorSteps: () => {
+        reading = false;
+      }
+    };
+    ReadableStreamBYOBReaderRead(reader, view, readIntoRequest);
+  }
+
+  function pull1Algorithm(): Promise<void> {
+    if (reading) {
+      return promiseResolvedWith(undefined);
+    }
+
+    reading = true;
+
+    const byobRequest = ReadableByteStreamControllerGetBYOBRequest(branch1._readableStreamController);
+    if (byobRequest === null) {
+      pullWithDefaultReader();
+    } else {
+      pullWithBYOBReader(byobRequest._view!, false);
+    }
+
+    return promiseResolvedWith(undefined);
+  }
+
+  function pull2Algorithm(): Promise<void> {
+    if (reading) {
+      return promiseResolvedWith(undefined);
+    }
+
+    reading = true;
+
+    const byobRequest = ReadableByteStreamControllerGetBYOBRequest(branch2._readableStreamController);
+    if (byobRequest === null) {
+      pullWithDefaultReader();
+    } else {
+      pullWithBYOBReader(byobRequest._view!, true);
+    }
+
+    return promiseResolvedWith(undefined);
+  }
+
+  function cancel1Algorithm(reason: any): Promise<void> {
+    canceled1 = true;
+    reason1 = reason;
+    if (canceled2) {
+      const compositeReason = CreateArrayFromList([reason1, reason2]);
+      const cancelResult = ReadableStreamCancel(stream, compositeReason);
+      resolveCancelPromise(cancelResult);
+    }
+    return cancelPromise;
+  }
+
+  function cancel2Algorithm(reason: any): Promise<void> {
+    canceled2 = true;
+    reason2 = reason;
+    if (canceled1) {
+      const compositeReason = CreateArrayFromList([reason1, reason2]);
+      const cancelResult = ReadableStreamCancel(stream, compositeReason);
+      resolveCancelPromise(cancelResult);
+    }
+    return cancelPromise;
+  }
+
+  function startAlgorithm(): void {
+    return;
+  }
+
+  branch1 = CreateReadableByteStream(startAlgorithm, pull1Algorithm, cancel1Algorithm);
+  branch2 = CreateReadableByteStream(startAlgorithm, pull2Algorithm, cancel2Algorithm);
+
+  forwardReaderError(reader);
 
   return [branch1, branch2];
 }

--- a/src/target/es5/stub/async-iterator-prototype.ts
+++ b/src/target/es5/stub/async-iterator-prototype.ts
@@ -8,8 +8,8 @@ if (typeof Symbol.asyncIterator === 'symbol') {
   AsyncIteratorPrototype = {
     // 25.1.3.1 %AsyncIteratorPrototype% [ @@asyncIterator ] ( )
     // https://tc39.github.io/ecma262/#sec-asynciteratorprototype-asynciterator
-    [Symbol.asyncIterator]() {
-      return this as any;
+    [Symbol.asyncIterator](this: AsyncIterator<any>) {
+      return this;
     }
   };
   Object.defineProperty(AsyncIteratorPrototype, Symbol.asyncIterator, { enumerable: false });

--- a/test/run-web-platform-tests.js
+++ b/test/run-web-platform-tests.js
@@ -50,6 +50,10 @@ async function main() {
     'readable-byte-streams/general.any.html': [
       'ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple respond() calls',
       'ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple enqueue() calls'
+    ],
+    // Same thing: the enqueued chunk will have the same buffer as branch1's chunk
+    'readable-byte-streams/tee.any.html': [
+      'ReadableStream teeing with byte source: chunks should be cloned for each branch'
     ]
   };
 

--- a/test/run-web-platform-tests.js
+++ b/test/run-web-platform-tests.js
@@ -91,6 +91,13 @@ async function main() {
       /interface: attribute/,
       // ES5 build has { writable: true } on prototype objects
       /interface: existence and properties of interface prototype object/
+    ],
+    'queuing-strategies.any.html': [
+      // ES5 build turns arrow functions into regular functions, which cannot be marked as non-constructable
+      'ByteLengthQueuingStrategy: size should not have a prototype property',
+      'CountQueuingStrategy: size should not have a prototype property',
+      'ByteLengthQueuingStrategy: size should not be a constructor',
+      'CountQueuingStrategy: size should not be a constructor'
     ]
   });
 

--- a/test/types/writable-stream.ts
+++ b/test/types/writable-stream.ts
@@ -37,7 +37,8 @@ const closePromise: Promise<void> = writableStream.close();
 const abortPromise: Promise<void> = writableStream.abort('aborted');
 
 // Compatibility with stream types from DOM
-const domUnderlyingSink: UnderlyingSink<string> = underlyingSink;
+// FIXME Re-enable when TypeScript types have been updated to match latest spec
+// const domUnderlyingSink: UnderlyingSink<string> = underlyingSink;
 const domWritableStream: WritableStream<string> = writableStream;
-const domController: WritableStreamDefaultController = controller;
+// const domController: WritableStreamDefaultController = controller;
 const domWriter: WritableStreamDefaultWriter<string> = writer;

--- a/test/types/writable-stream.ts
+++ b/test/types/writable-stream.ts
@@ -22,6 +22,9 @@ const writableStream: polyfill.WritableStream<string> = new polyfill.WritableStr
   { highWaterMark: 0, size: (chunk: string) => 1 }
 );
 
+const controllerSignal: polyfill.AbortSignal = controller.signal;
+const controllerAbortReason: any = controller.abortReason;
+
 const locked: boolean = writableStream.locked;
 
 const writer: polyfill.WritableStreamDefaultWriter<string> = writableStream.getWriter();


### PR DESCRIPTION
This aligns the implementation with [spec version `cada812` of 8 July 2021](https://streams.spec.whatwg.org/commit-snapshots/cada8129edcc4803b2878a7a3f5e1d8325dc0c23/).

Comparison: https://github.com/whatwg/streams/compare/c5ca8837c0b50ad1057351a7676824013c36538e...cada8129edcc4803b2878a7a3f5e1d8325dc0c23