### PR TITLE
When using Bluebird warning are raied about created but not returned promises

### DIFF
--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -996,17 +996,11 @@ export function SetUpReadableByteStreamControllerFromUnderlyingSource(
   const controller: ReadableByteStreamController = Object.create(ReadableByteStreamController.prototype);
 
   let startAlgorithm: () => void | PromiseLike<void> = () => undefined;
-  let pullAlgorithm: () => Promise<void> = () => promiseResolvedWith(undefined);
-  let cancelAlgorithm: (reason: any) => Promise<void> = () => promiseResolvedWith(undefined);
+  let pullAlgorithm: () => Promise<void> = underlyingByteSource.pull !== undefined ? () => underlyingByteSource.pull!(controller) : () => promiseResolvedWith(undefined);
+  let cancelAlgorithm: (reason: any) => Promise<void> = underlyingByteSource.cancel !== undefined ? reason => underlyingByteSource.cancel!(reason) : () => promiseResolvedWith(undefined);
 
   if (underlyingByteSource.start !== undefined) {
     startAlgorithm = () => underlyingByteSource.start!(controller);
-  }
-  if (underlyingByteSource.pull !== undefined) {
-    pullAlgorithm = () => underlyingByteSource.pull!(controller);
-  }
-  if (underlyingByteSource.cancel !== undefined) {
-    cancelAlgorithm = reason => underlyingByteSource.cancel!(reason);
   }
 
   const autoAllocateChunkSize = underlyingByteSource.autoAllocateChunkSize;

--- a/src/lib/readable-stream/default-controller.ts
+++ b/src/lib/readable-stream/default-controller.ts
@@ -375,17 +375,11 @@ export function SetUpReadableStreamDefaultControllerFromUnderlyingSource<R>(
   const controller: ReadableStreamDefaultController<R> = Object.create(ReadableStreamDefaultController.prototype);
 
   let startAlgorithm: () => void | PromiseLike<void> = () => undefined;
-  let pullAlgorithm: () => Promise<void> = () => promiseResolvedWith(undefined);
-  let cancelAlgorithm: (reason: any) => Promise<void> = () => promiseResolvedWith(undefined);
+  let pullAlgorithm: () => Promise<void> = underlyingSource.pull !== undefined ? () => underlyingSource.pull!(controller) : () => promiseResolvedWith(undefined);
+  let cancelAlgorithm: (reason: any) => Promise<void> = underlyingSource.cancel !== undefined ? reason => underlyingSource.cancel!(reason) : () => promiseResolvedWith(undefined);
 
   if (underlyingSource.start !== undefined) {
     startAlgorithm = () => underlyingSource.start!(controller);
-  }
-  if (underlyingSource.pull !== undefined) {
-    pullAlgorithm = () => underlyingSource.pull!(controller);
-  }
-  if (underlyingSource.cancel !== undefined) {
-    cancelAlgorithm = reason => underlyingSource.cancel!(reason);
   }
 
   SetUpReadableStreamDefaultController(


### PR DESCRIPTION
```(node:191) Warning: a promise was created in a handler as internals/timers.js:461:21 but was not returned from it, see http://goo.gl/rRqMUw at function.originalPromiseResolve (/..../node_modules/bluebird/js/release/promise.js:225:13)```
To fix that,variables `pullAlgorithm` and `cancelAlgorithm` were defined with default promise on them and then reassigned with new promises.

When using node streams in functions `SetUpReadableByteStreamControllerFromUnderlyingSource` and `SetUpReadableStreamDefaultControllerFromUnderlyingSource` 2 Promises (for each function) were created and then replaced (without executing them) with new ones. This fixes that.

This only occured while project was using Bluebird promises.