### PR TITLE
Prevent Bluebird warning about a promise not being returned from a handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 🐛 Prevent [warnings from Bluebird](http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it) about a promise being created within a handler but not being returned from a handler. ([#91](https://github.com/MattiasBuelens/web-streams-polyfill/pull/91))
+
 ## v4.0.0-beta.1 (2021-09-06)
 
 * 💥 Rework the list of variants to have more modern defaults.

--- a/src/lib/helpers/webidl.ts
+++ b/src/lib/helpers/webidl.ts
@@ -30,10 +30,13 @@ export function PerformPromiseThen<T, TResult1 = T, TResult2 = never>(
   return originalPromiseThen.call(promise, onFulfilled, onRejected) as Promise<TResult1 | TResult2>;
 }
 
+// Bluebird logs a warning when a promise is created within a fulfillment handler, but then isn't returned
+// from that handler. To prevent this, return null instead of void from all handlers.
+// http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it
 export function uponPromise<T>(
   promise: Promise<T>,
-  onFulfilled?: (value: T) => void | PromiseLike<void>,
-  onRejected?: (reason: any) => void | PromiseLike<void>): void {
+  onFulfilled?: (value: T) => null | PromiseLike<null>,
+  onRejected?: (reason: any) => null | PromiseLike<null>): void {
   PerformPromiseThen(
     PerformPromiseThen(promise, onFulfilled, onRejected),
     undefined,
@@ -41,11 +44,11 @@ export function uponPromise<T>(
   );
 }
 
-export function uponFulfillment<T>(promise: Promise<T>, onFulfilled: (value: T) => void | PromiseLike<void>): void {
+export function uponFulfillment<T>(promise: Promise<T>, onFulfilled: (value: T) => null | PromiseLike<null>): void {
   uponPromise(promise, onFulfilled);
 }
 
-export function uponRejection(promise: Promise<unknown>, onRejected: (reason: any) => void | PromiseLike<void>): void {
+export function uponRejection(promise: Promise<unknown>, onRejected: (reason: any) => null | PromiseLike<null>): void {
   uponPromise(promise, undefined, onRejected);
 }
 

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -421,9 +421,12 @@ function ReadableByteStreamControllerCallPullIfNeeded(controller: ReadableByteSt
         controller._pullAgain = false;
         ReadableByteStreamControllerCallPullIfNeeded(controller);
       }
+
+      return null;
     },
     e => {
       ReadableByteStreamControllerError(controller, e);
+      return null;
     }
   );
 }
@@ -981,9 +984,11 @@ export function SetUpReadableByteStreamController(stream: ReadableByteStream,
       assert(!controller._pullAgain);
 
       ReadableByteStreamControllerCallPullIfNeeded(controller);
+      return null;
     },
     r => {
       ReadableByteStreamControllerError(controller, r);
+      return null;
     }
   );
 }

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -995,18 +995,24 @@ export function SetUpReadableByteStreamControllerFromUnderlyingSource(
 ) {
   const controller: ReadableByteStreamController = Object.create(ReadableByteStreamController.prototype);
 
-  let startAlgorithm: () => void | PromiseLike<void> = () => undefined;
-  let pullAlgorithm: () => Promise<void> = () => promiseResolvedWith(undefined);
-  let cancelAlgorithm: (reason: any) => Promise<void> = () => promiseResolvedWith(undefined);
+  let startAlgorithm: () => void | PromiseLike<void>;
+  let pullAlgorithm: () => Promise<void>;
+  let cancelAlgorithm: (reason: any) => Promise<void>;
 
   if (underlyingByteSource.start !== undefined) {
     startAlgorithm = () => underlyingByteSource.start!(controller);
+  } else {
+    startAlgorithm = () => undefined;
   }
   if (underlyingByteSource.pull !== undefined) {
     pullAlgorithm = () => underlyingByteSource.pull!(controller);
+  } else {
+    pullAlgorithm = () => promiseResolvedWith(undefined);
   }
   if (underlyingByteSource.cancel !== undefined) {
     cancelAlgorithm = reason => underlyingByteSource.cancel!(reason);
+  } else {
+    cancelAlgorithm = () => promiseResolvedWith(undefined);
   }
 
   const autoAllocateChunkSize = underlyingByteSource.autoAllocateChunkSize;

--- a/src/lib/readable-stream/default-controller.ts
+++ b/src/lib/readable-stream/default-controller.ts
@@ -184,9 +184,12 @@ function ReadableStreamDefaultControllerCallPullIfNeeded(controller: ReadableStr
         controller._pullAgain = false;
         ReadableStreamDefaultControllerCallPullIfNeeded(controller);
       }
+
+      return null;
     },
     e => {
       ReadableStreamDefaultControllerError(controller, e);
+      return null;
     }
   );
 }
@@ -359,9 +362,11 @@ export function SetUpReadableStreamDefaultController<R>(stream: ReadableStream<R
       assert(!controller._pullAgain);
 
       ReadableStreamDefaultControllerCallPullIfNeeded(controller);
+      return null;
     },
     r => {
       ReadableStreamDefaultControllerError(controller, r);
+      return null;
     }
   );
 }

--- a/src/lib/readable-stream/default-controller.ts
+++ b/src/lib/readable-stream/default-controller.ts
@@ -374,18 +374,24 @@ export function SetUpReadableStreamDefaultControllerFromUnderlyingSource<R>(
 ) {
   const controller: ReadableStreamDefaultController<R> = Object.create(ReadableStreamDefaultController.prototype);
 
-  let startAlgorithm: () => void | PromiseLike<void> = () => undefined;
-  let pullAlgorithm: () => Promise<void> = () => promiseResolvedWith(undefined);
-  let cancelAlgorithm: (reason: any) => Promise<void> = () => promiseResolvedWith(undefined);
+  let startAlgorithm: () => void | PromiseLike<void>;
+  let pullAlgorithm: () => Promise<void>;
+  let cancelAlgorithm: (reason: any) => Promise<void>;
 
   if (underlyingSource.start !== undefined) {
     startAlgorithm = () => underlyingSource.start!(controller);
+  } else {
+    startAlgorithm = () => undefined;
   }
   if (underlyingSource.pull !== undefined) {
     pullAlgorithm = () => underlyingSource.pull!(controller);
+  } else {
+    pullAlgorithm = () => promiseResolvedWith(undefined);
   }
   if (underlyingSource.cancel !== undefined) {
     cancelAlgorithm = reason => underlyingSource.cancel!(reason);
+  } else {
+    cancelAlgorithm = () => promiseResolvedWith(undefined);
   }
 
   SetUpReadableStreamDefaultController(

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -132,6 +132,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
       } else {
         shutdown(true, storedError);
       }
+      return null;
     });
 
     // Errors must be propagated backward
@@ -141,6 +142,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
       } else {
         shutdown(true, storedError);
       }
+      return null;
     });
 
     // Closing must be propagated forward
@@ -150,6 +152,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
       } else {
         shutdown();
       }
+      return null;
     });
 
     // Closing must be propagated backward
@@ -177,7 +180,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
 
     function isOrBecomesErrored(stream: ReadableStream | WritableStream,
                                 promise: Promise<void>,
-                                action: (reason: any) => void) {
+                                action: (reason: any) => null) {
       if (stream._state === 'errored') {
         action(stream._storedError);
       } else {
@@ -185,7 +188,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
       }
     }
 
-    function isOrBecomesClosed(stream: ReadableStream | WritableStream, promise: Promise<void>, action: () => void) {
+    function isOrBecomesClosed(stream: ReadableStream | WritableStream, promise: Promise<void>, action: () => null) {
       if (stream._state === 'closed') {
         action();
       } else {
@@ -205,12 +208,13 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
         doTheRest();
       }
 
-      function doTheRest() {
+      function doTheRest(): null {
         uponPromise(
           action(),
           () => finalize(originalIsError, originalError),
           newError => finalize(true, newError)
         );
+        return null;
       }
     }
 
@@ -227,7 +231,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
       }
     }
 
-    function finalize(isError?: boolean, error?: any) {
+    function finalize(isError?: boolean, error?: any): null {
       WritableStreamDefaultWriterRelease(writer);
       ReadableStreamReaderGenericRelease(reader);
 
@@ -239,6 +243,8 @@ export function ReadableStreamPipeTo<T>(source: ReadableStream<T>,
       } else {
         resolve(undefined);
       }
+
+      return null;
     }
   });
 }

--- a/src/lib/readable-stream/tee.ts
+++ b/src/lib/readable-stream/tee.ts
@@ -166,6 +166,7 @@ export function ReadableStreamDefaultTee<R>(stream: ReadableStream<R>,
     if (!canceled1 || !canceled2) {
       resolveCancelPromise(undefined);
     }
+    return null;
   });
 
   return [branch1, branch2];
@@ -192,13 +193,14 @@ export function ReadableByteStreamTee(stream: ReadableByteStream): [ReadableByte
   function forwardReaderError(thisReader: ReadableStreamReader<Uint8Array>) {
     uponRejection(thisReader._closedPromise, r => {
       if (thisReader !== reader) {
-        return;
+        return null;
       }
       ReadableByteStreamControllerError(branch1._readableStreamController, r);
       ReadableByteStreamControllerError(branch2._readableStreamController, r);
       if (!canceled1 || !canceled2) {
         resolveCancelPromise(undefined);
       }
+      return null;
     });
   }
 

--- a/src/lib/transform-stream.ts
+++ b/src/lib/transform-stream.ts
@@ -371,22 +371,26 @@ function SetUpTransformStreamDefaultControllerFromTransformer<I, O>(stream: Tran
                                                                     transformer: ValidatedTransformer<I, O>) {
   const controller: TransformStreamDefaultController<O> = Object.create(TransformStreamDefaultController.prototype);
 
-  let transformAlgorithm = (chunk: I): Promise<void> => {
-    try {
-      TransformStreamDefaultControllerEnqueue(controller, chunk as unknown as O);
-      return promiseResolvedWith(undefined);
-    } catch (transformResultE) {
-      return promiseRejectedWith(transformResultE);
-    }
-  };
-
-  let flushAlgorithm: () => Promise<void> = () => promiseResolvedWith(undefined);
+  let transformAlgorithm: (chunk: I) => Promise<void>;
+  let flushAlgorithm: () => Promise<void>;
 
   if (transformer.transform !== undefined) {
     transformAlgorithm = chunk => transformer.transform!(chunk, controller);
+  } else {
+    transformAlgorithm = chunk => {
+      try {
+        TransformStreamDefaultControllerEnqueue(controller, chunk as unknown as O);
+        return promiseResolvedWith(undefined);
+      } catch (transformResultE) {
+        return promiseRejectedWith(transformResultE);
+      }
+    };
   }
+
   if (transformer.flush !== undefined) {
     flushAlgorithm = () => transformer.flush!(controller);
+  } else {
+    flushAlgorithm = () => promiseResolvedWith(undefined);
   }
 
   SetUpTransformStreamDefaultController(stream, controller, transformAlgorithm, flushAlgorithm);

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -447,10 +447,12 @@ function WritableStreamFinishErroring(stream: WritableStream) {
     () => {
       abortRequest._resolve();
       WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
+      return null;
     },
     (reason: any) => {
       abortRequest._reject(reason);
       WritableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
+      return null;
     });
 }
 
@@ -1081,11 +1083,13 @@ function SetUpWritableStreamDefaultController<W>(stream: WritableStream<W>,
       assert(stream._state === 'writable' || stream._state === 'erroring');
       controller._started = true;
       WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller);
+      return null;
     },
     r => {
       assert(stream._state === 'writable' || stream._state === 'erroring');
       controller._started = true;
       WritableStreamDealWithRejection(stream, r);
+      return null;
     }
   );
 }
@@ -1225,9 +1229,11 @@ function WritableStreamDefaultControllerProcessClose(controller: WritableStreamD
     sinkClosePromise,
     () => {
       WritableStreamFinishInFlightClose(stream);
+      return null;
     },
     reason => {
       WritableStreamFinishInFlightCloseWithError(stream, reason);
+      return null;
     }
   );
 }
@@ -1254,12 +1260,14 @@ function WritableStreamDefaultControllerProcessWrite<W>(controller: WritableStre
       }
 
       WritableStreamDefaultControllerAdvanceQueueIfNeeded(controller);
+      return null;
     },
     reason => {
       if (stream._state === 'writable') {
         WritableStreamDefaultControllerClearAlgorithms(controller);
       }
       WritableStreamFinishInFlightWriteWithError(stream, reason);
+      return null;
     }
   );
 }

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -1096,22 +1096,30 @@ function SetUpWritableStreamDefaultControllerFromUnderlyingSink<W>(stream: Writa
                                                                    sizeAlgorithm: QueuingStrategySizeCallback<W>) {
   const controller = Object.create(WritableStreamDefaultController.prototype);
 
-  let startAlgorithm: () => void | PromiseLike<void> = () => undefined;
-  let writeAlgorithm: (chunk: W) => Promise<void> = () => promiseResolvedWith(undefined);
-  let closeAlgorithm: () => Promise<void> = () => promiseResolvedWith(undefined);
-  let abortAlgorithm: (reason: any) => Promise<void> = () => promiseResolvedWith(undefined);
+  let startAlgorithm: () => void | PromiseLike<void>;
+  let writeAlgorithm: (chunk: W) => Promise<void>;
+  let closeAlgorithm: () => Promise<void>;
+  let abortAlgorithm: (reason: any) => Promise<void>;
 
   if (underlyingSink.start !== undefined) {
     startAlgorithm = () => underlyingSink.start!(controller);
+  } else {
+    startAlgorithm = () => undefined;
   }
   if (underlyingSink.write !== undefined) {
     writeAlgorithm = chunk => underlyingSink.write!(chunk, controller);
+  } else {
+    writeAlgorithm = () => promiseResolvedWith(undefined);
   }
   if (underlyingSink.close !== undefined) {
     closeAlgorithm = () => underlyingSink.close!();
+  } else {
+    closeAlgorithm = () => promiseResolvedWith(undefined);
   }
   if (underlyingSink.abort !== undefined) {
     abortAlgorithm = reason => underlyingSink.abort!(reason);
+  } else {
+    abortAlgorithm = () => promiseResolvedWith(undefined);
   }
 
   SetUpWritableStreamDefaultController(


### PR DESCRIPTION
The polyfill often creates new promises within a fulfillment/rejection handler of a different promise, without returning that new promise. Bluebird thinks this might be a mistake, and [logs a warning when this happens](http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it). However, in our case, these are *not* mistakes.

Reproducing this issue is surprisingly easy. Even basic usage of the polyfill is enough to trigger these warnings:
```html
<script src="https://cdn.jsdelivr.net/bluebird/latest/bluebird.js"></script>
<script src="https://unpkg.com/web-streams-polyfill@3.1.1/dist/polyfill.min.js"></script>
<script>
const rs = new ReadableStream({
  start(c) {
    c.enqueue('a');
    c.enqueue('b');
    c.close();
  }
});
const ws = new WritableStream({
  write(chunk, c) {
    console.log(chunk);
  }
});
rs.pipeTo(ws);
</script>
```

Fix it by returning `null` from all problematic fulfillment/rejection handlers, to suppress these warnings.

Supersedes #90.