### PR TITLE
Loosen brand checks on ReadableStream methods

### DIFF
--- a/src/lib/abstract-ops/ecmascript.ts
+++ b/src/lib/abstract-ops/ecmascript.ts
@@ -1,9 +1,3 @@
-export function CreateArrayFromList<T extends any[]>(elements: T): T {
-  // We use arrays to represent lists, so this is basically a no-op.
-  // Do a slice though just in case we happen to depend on the unique-ness.
-  return elements.slice() as T;
-}
-
 export function CopyDataBlockBytes(dest: ArrayBuffer,
                                    destOffset: number,
                                    src: ArrayBuffer,

--- a/src/lib/helpers/stream-like.ts
+++ b/src/lib/helpers/stream-like.ts
@@ -1,0 +1,89 @@
+import { typeIsObject } from './miscellaneous';
+import assert from '../../stub/assert';
+import type { ReadableStreamBYOBReadResult, ReadableStreamDefaultReadResult } from '../readable-stream';
+
+// For methods like ReadableStream.pipeTo() or .tee(), we want the polyfill's implementation to be compatible
+// with *any* streams implementation, including native streams or a different polyfill.
+// These types define the minimal API that the polyfill *may* expect from such implementations.
+// Importantly, these do not have any internal fields and cannot be used by the internal abstract ops,
+// so the polyfill can *only* use their public API.
+
+export interface ReadableStreamLike<R = any> {
+  readonly locked: boolean;
+
+  getReader(): ReadableStreamDefaultReaderLike<R>;
+}
+
+export interface ReadableByteStreamLike extends ReadableStreamLike<Uint8Array> {
+  getReader({ mode }: { mode: 'byob' }): ReadableStreamBYOBReaderLike;
+
+  getReader(): ReadableStreamDefaultReaderLike<Uint8Array>;
+}
+
+export interface ReadableStreamDefaultReaderLike<R = any> {
+  readonly closed: Promise<void>;
+
+  cancel(reason?: any): Promise<void>;
+
+  read(): Promise<ReadableStreamDefaultReadResult<R>>;
+
+  releaseLock(): void;
+}
+
+export interface ReadableStreamBYOBReaderLike {
+  readonly closed: Promise<void>;
+
+  cancel(reason?: any): Promise<void>;
+
+  read<T extends ArrayBufferView>(view: T): Promise<ReadableStreamBYOBReadResult<T>>;
+
+  releaseLock(): void;
+}
+
+export type ReadableStreamReaderLike<R = any> = ReadableStreamDefaultReaderLike<R> | ReadableStreamBYOBReaderLike;
+
+export interface WritableStreamLike<W = any> {
+  readonly locked: boolean;
+
+  getWriter(): WritableStreamDefaultWriterLike<W>;
+}
+
+interface WritableStreamDefaultWriterLike<W = any> {
+  readonly closed: Promise<undefined>;
+  readonly desiredSize: number | null;
+  readonly ready: Promise<undefined>;
+
+  abort(reason?: any): Promise<void>;
+
+  close(): Promise<void>;
+
+  releaseLock(): void;
+
+  write(chunk: W): Promise<void>;
+}
+
+export function IsReadableStreamLike(x: unknown): x is ReadableStreamLike {
+  return typeIsObject(x) && typeof (x as ReadableStreamLike).getReader === 'function';
+}
+
+export function IsReadableByteStreamLike(x: unknown): x is ReadableByteStreamLike {
+  if (!IsReadableStreamLike(x)) {
+    return false;
+  }
+
+  // This brand check only works for unlocked streams.
+  // If the stream is locked, getReader() will throw even if "byob" is actually supported.
+  assert(!x.locked);
+
+  try {
+    (x as ReadableByteStreamLike).getReader({ mode: 'byob' }).releaseLock();
+    return true;
+  } catch {
+    // getReader() throws if mode is not supported
+    return false;
+  }
+}
+
+export function IsWritableStreamLike(x: unknown): x is WritableStreamLike {
+  return typeIsObject(x) && typeof (x as WritableStreamLike).getWriter === 'function';
+}

--- a/src/lib/helpers/stream-like.ts
+++ b/src/lib/helpers/stream-like.ts
@@ -63,13 +63,23 @@ interface WritableStreamDefaultWriterLike<W = any> {
 }
 
 export function IsReadableStreamLike(x: unknown): x is ReadableStreamLike {
-  return typeIsObject(x) && typeof (x as ReadableStreamLike).getReader === 'function';
-}
-
-export function IsReadableByteStreamLike(x: unknown): x is ReadableByteStreamLike {
-  if (!IsReadableStreamLike(x)) {
+  if (!typeIsObject(x)) {
     return false;
   }
+  if (typeof (x as ReadableStreamLike).getReader !== 'function') {
+    return false;
+  }
+  try {
+    // noinspection SuspiciousTypeOfGuard
+    return typeof (x as ReadableStreamLike).locked === 'boolean';
+  } catch {
+    // ReadableStream.prototype.locked may throw if its brand check fails
+    return false;
+  }
+}
+
+export function IsReadableByteStreamLike(x: ReadableStreamLike): x is ReadableByteStreamLike {
+  assert(IsReadableStreamLike(x));
 
   // This brand check only works for unlocked streams.
   // If the stream is locked, getReader() will throw even if "byob" is actually supported.
@@ -85,5 +95,17 @@ export function IsReadableByteStreamLike(x: unknown): x is ReadableByteStreamLik
 }
 
 export function IsWritableStreamLike(x: unknown): x is WritableStreamLike {
-  return typeIsObject(x) && typeof (x as WritableStreamLike).getWriter === 'function';
+  if (!typeIsObject(x)) {
+    return false;
+  }
+  if (typeof (x as WritableStreamLike).getWriter !== 'function') {
+    return false;
+  }
+  try {
+    // noinspection SuspiciousTypeOfGuard
+    return typeof (x as WritableStreamLike).locked === 'boolean';
+  } catch {
+    // WritableStream.prototype.locked may throw if its brand check fails
+    return false;
+  }
 }

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -48,7 +48,6 @@ import {
 } from './readable-stream/underlying-source';
 import { noop } from '../utils';
 import { typeIsObject } from './helpers/miscellaneous';
-import { CreateArrayFromList } from './abstract-ops/ecmascript';
 import { CancelSteps } from './abstract-ops/internal-methods';
 import { IsNonNegativeNumber } from './abstract-ops/miscellaneous';
 import { assertObject, assertRequiredArgument } from './validators/basic';
@@ -298,8 +297,7 @@ export class ReadableStream<R = any> {
       throw new TypeError('Cannot tee a stream that already has a reader');
     }
 
-    const branches = ReadableStreamTee(this, false);
-    return CreateArrayFromList(branches);
+    return ReadableStreamTee(this, false);
   }
 
   /**

--- a/src/lib/validators/readable-stream.ts
+++ b/src/lib/validators/readable-stream.ts
@@ -1,8 +1,16 @@
 import type { ReadableStream } from '../readable-stream';
 import { IsReadableStream } from '../readable-stream';
+import type { ReadableStreamLike } from '../helpers/stream-like';
+import { IsReadableStreamLike } from '../helpers/stream-like';
 
 export function assertReadableStream(x: unknown, context: string): asserts x is ReadableStream {
   if (!IsReadableStream(x)) {
+    throw new TypeError(`${context} is not a ReadableStream.`);
+  }
+}
+
+export function assertReadableStreamLike(x: unknown, context: string): asserts x is ReadableStreamLike {
+  if (!IsReadableStreamLike(x)) {
     throw new TypeError(`${context} is not a ReadableStream.`);
   }
 }

--- a/src/lib/validators/readable-writable-pair.ts
+++ b/src/lib/validators/readable-writable-pair.ts
@@ -1,10 +1,9 @@
 import { assertDictionary, assertRequiredField } from './basic';
-import type { ReadableStream } from '../readable-stream';
-import type { WritableStream } from '../writable-stream';
-import { assertReadableStream } from './readable-stream';
-import { assertWritableStream } from './writable-stream';
+import type { ReadableStreamLike, WritableStreamLike } from '../helpers/stream-like';
+import { assertReadableStreamLike } from './readable-stream';
+import { assertWritableStreamLike } from './writable-stream';
 
-export function convertReadableWritablePair<RS extends ReadableStream, WS extends WritableStream>(
+export function convertReadableWritablePair<RS extends ReadableStreamLike, WS extends WritableStreamLike>(
   pair: { readable: RS; writable: WS } | null | undefined,
   context: string
 ): { readable: RS; writable: WS } {
@@ -12,11 +11,11 @@ export function convertReadableWritablePair<RS extends ReadableStream, WS extend
 
   const readable = pair?.readable;
   assertRequiredField(readable, 'readable', 'ReadableWritablePair');
-  assertReadableStream(readable, `${context} has member 'readable' that`);
+  assertReadableStreamLike(readable, `${context} has member 'readable' that`);
 
   const writable = pair?.writable;
   assertRequiredField(writable, 'writable', 'ReadableWritablePair');
-  assertWritableStream(writable, `${context} has member 'writable' that`);
+  assertWritableStreamLike(writable, `${context} has member 'writable' that`);
 
   return { readable, writable };
 }

--- a/src/lib/validators/writable-stream.ts
+++ b/src/lib/validators/writable-stream.ts
@@ -1,8 +1,16 @@
 import type { WritableStream } from '../writable-stream';
 import { IsWritableStream } from '../writable-stream';
+import type { WritableStreamLike } from '../helpers/stream-like';
+import { IsWritableStreamLike } from '../helpers/stream-like';
 
 export function assertWritableStream(x: unknown, context: string): asserts x is WritableStream {
   if (!IsWritableStream(x)) {
+    throw new TypeError(`${context} is not a WritableStream.`);
+  }
+}
+
+export function assertWritableStreamLike(x: unknown, context: string): asserts x is WritableStreamLike {
+  if (!IsWritableStreamLike(x)) {
     throw new TypeError(`${context} is not a WritableStream.`);
   }
 }


### PR DESCRIPTION
In #96, #98 and #99, we made `pipeTo()`, `pipeThrough()`, `tee()` and `[Symbol.asyncIterator]()` use *only* the public API rather than relying on internal abstract operations.

This PR brings it all together by loosening the brand checks on these methods. You'll now be able to call `readable.pipeTo(writable)` with *any* `writable` that "looks like" a `WritableStream`, i.e. anything that has a sufficiently compliant `getWriter()` method. This includes native `WritableStream`s, or even `WritableStream`s constructed by a different polyfill. 😁

In theory, you could also call these on anything that "looks like" a `ReadableStream`, although it's currently still a bit awkward:
```javascript
import { ReadableStream, WritableStream } from 'web-streams-polyfill';
const nativeReadable = new Response("Hello world!").body;
const destination = new WritableStream({ /* ... */ });
const pipePromise = ReadableStream.prototype.pipeTo.call(nativeReadable, destination);
```