### PR TITLE
Deprecate WritableStreamDefaultController.abortReason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,15 @@
 > - 👓 Spec Compliance
 > - 🚀 New Feature
 > - 🐛 Bug Fix
+> - 👎 Deprecation
 > - 📝 Documentation
 > - 🏠 Internal
 > - 💅 Polish
 
 ## Unreleased
 
+* 👎 Deprecate `WritableStreamDefaultController.abortReason` ([#102](https://github.com/MattiasBuelens/web-streams-polyfill/pull/102))
+  * Use `WritableStreamDefaultController.signal.reason` instead.
 * 👓 Align with [spec version `4b6b93c`](https://github.com/whatwg/streams/tree/4b6b93c69e531e2fe45a6ed4cb1484a7ba4eb8bb/) ([#103](https://github.com/MattiasBuelens/web-streams-polyfill/pull/103))
 
 ## v3.1.1 (2021-09-06)

--- a/etc/web-streams-polyfill.api.md
+++ b/etc/web-streams-polyfill.api.md
@@ -252,6 +252,7 @@ export class WritableStream<W = any> {
 
 // @public
 export class WritableStreamDefaultController<W = any> {
+    // @deprecated
     get abortReason(): any;
     error(e?: any): void;
     get signal(): AbortSignal;

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -958,6 +958,10 @@ export class WritableStreamDefaultController<W = any> {
 
   /**
    * The reason which was passed to `WritableStream.abort(reason)` when the stream was aborted.
+   *
+   * @deprecated
+   *  This property has been removed from the specification, see https://github.com/whatwg/streams/pull/1177.
+   *  Use {@link WritableStreamDefaultController.signal}'s `reason` instead.
    */
   get abortReason(): any {
     if (!IsWritableStreamDefaultController(this)) {


### PR DESCRIPTION
This property has been removed from the specification, see whatwg/streams#1177.

We'll deprecate the property for now, and remove it in 4.0. Users should switch to `WritableStreamDefaultController.signal.reason` instead, assuming they use an up-to-date `AbortController` polyfill.