### PR TITLE
Update to spec version of 25 October 2021 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 👓 Align with [spec version `4b6b93c`](https://github.com/whatwg/streams/tree/4b6b93c69e531e2fe45a6ed4cb1484a7ba4eb8bb/) ([#103](https://github.com/MattiasBuelens/web-streams-polyfill/pull/103))
+
 ## v3.1.1 (2021-09-06)
 
 * 🐛 Fix compatibility with TypeScript's DOM types for `ReadableStream` and `TransformStream` ([#85](https://github.com/MattiasBuelens/web-streams-polyfill/issues/85), [#86](https://github.com/MattiasBuelens/web-streams-polyfill/pull/86))

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The `polyfill/es2018` and `ponyfill/es2018` variants work in any ES2018-compatib
 
 ### Compliance
 
-The polyfill implements [version `cada812` (8 Jul 2021)][spec-snapshot] of the streams specification.
+The polyfill implements [version `4b6b93c` (25 Oct 2021)][spec-snapshot] of the streams specification.
 
 The polyfill is tested against the same [web platform tests][wpt] that are used by browsers to test their native implementations.
 The polyfill aims to pass all tests, although it allows some exceptions for practical reasons:
@@ -103,12 +103,12 @@ Thanks to these people for their work on [the original polyfill][creatorrr-polyf
 [rs-asynciterator]: https://streams.spec.whatwg.org/#rs-asynciterator
 [ws-controller-signal]: https://streams.spec.whatwg.org/#ws-default-controller-signal
 [abortcontroller-polyfill]: https://www.npmjs.com/package/abortcontroller-polyfill
-[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/cada8129edcc4803b2878a7a3f5e1d8325dc0c23/
-[wpt]: https://github.com/web-platform-tests/wpt/tree/87a4c80598aee5178c385628174f1832f5a28ad6/streams
-[wpt-bad-buffers]: https://github.com/web-platform-tests/wpt/blob/87a4c80598aee5178c385628174f1832f5a28ad6/streams/readable-byte-streams/bad-buffers-and-views.any.js
+[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/4b6b93c69e531e2fe45a6ed4cb1484a7ba4eb8bb/
+[wpt]: https://github.com/web-platform-tests/wpt/tree/96ca25f0f7526282c0d47e6bf6a7edd439da1968/streams
+[wpt-bad-buffers]: https://github.com/web-platform-tests/wpt/blob/96ca25f0f7526282c0d47e6bf6a7edd439da1968/streams/readable-byte-streams/bad-buffers-and-views.any.js
 [proposal-arraybuffer-transfer]: https://github.com/domenic/proposal-arraybuffer-transfer
-[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/cada8129edcc4803b2878a7a3f5e1d8325dc0c23/reference-implementation/lib/abstract-ops/ecmascript.js#L16
+[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/4b6b93c69e531e2fe45a6ed4cb1484a7ba4eb8bb/reference-implementation/lib/abstract-ops/ecmascript.js#L16
 [issue-3]: https://github.com/MattiasBuelens/web-streams-polyfill/issues/3
-[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/87a4c80598aee5178c385628174f1832f5a28ad6/streams/readable-streams/async-iterator.any.js#L24
+[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/96ca25f0f7526282c0d47e6bf6a7edd439da1968/streams/readable-streams/async-iterator.any.js#L24
 [stub-async-iterator-prototype]: https://github.com/MattiasBuelens/web-streams-polyfill/blob/v2.0.0/src/target/es5/stub/async-iterator-prototype.ts
 [creatorrr-polyfill]: https://github.com/creatorrr/web-streams-polyfill

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -932,9 +932,9 @@ export function ReadableByteStreamControllerRespondWithNewView(controller: Reada
     throw new RangeError('The region specified by view is larger than byobRequest');
   }
 
+  const viewByteLength = view.byteLength;
   firstDescriptor.buffer = TransferArrayBuffer(view.buffer);
-
-  ReadableByteStreamControllerRespondInternal(controller, view.byteLength);
+  ReadableByteStreamControllerRespondInternal(controller, viewByteLength);
 }
 
 export function SetUpReadableByteStreamController(stream: ReadableByteStream,

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -810,10 +810,14 @@ export function ReadableByteStreamControllerEnqueue(controller: ReadableByteStre
 
   if (ReadableStreamHasDefaultReader(stream)) {
     if (ReadableStreamGetNumReadRequests(stream) === 0) {
+      assert(controller._pendingPullIntos.length === 0);
       ReadableByteStreamControllerEnqueueChunkToQueue(controller, transferredBuffer, byteOffset, byteLength);
     } else {
       assert(controller._queue.length === 0);
-
+      if (controller._pendingPullIntos.length > 0) {
+        assert(controller._pendingPullIntos.peek().readerType === 'default');
+        ReadableByteStreamControllerShiftPendingPullInto(controller);
+      }
       const transferredView = new Uint8Array(transferredBuffer, byteOffset, byteLength);
       ReadableStreamFulfillReadRequest(stream, transferredView, false);
     }

--- a/src/lib/writable-stream.ts
+++ b/src/lib/writable-stream.ts
@@ -1017,6 +1017,8 @@ export class WritableStreamDefaultController<W = any> {
 }
 
 Object.defineProperties(WritableStreamDefaultController.prototype, {
+  abortReason: { enumerable: true },
+  signal: { enumerable: true },
   error: { enumerable: true }
 });
 if (typeof Symbol.toStringTag === 'symbol') {


### PR DESCRIPTION
This aligns the implementation with [spec version `4b6b93c` of 25 October 2021](https://streams.spec.whatwg.org/commit-snapshots/4b6b93c69e531e2fe45a6ed4cb1484a7ba4eb8bb/).

Comparison: https://github.com/whatwg/streams/compare/cada8129edcc4803b2878a7a3f5e1d8325dc0c23...4b6b93c69e531e2fe45a6ed4cb1484a7ba4eb8bb