### PR TITLE
Add fallback for package exports

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -19,6 +19,9 @@ publishing npm packages.
   a [dual module (UMD/ESM)](https://nodejs.org/api/packages.html#packages_dual_commonjs_es_module_packages). You need
   Node 12.20.0 or higher to resolve these variants. If you're using a bundler (like webpack or Rollup), you need to make
   sure it's up-to-date too.
+  * For backwards compatibility, a fallback is provided that uses the same structure as in version 3. This should help
+    for older versions of Node or when using TypeScript 4.5 or lower, which do not (yet) understand package entry points.
+    If you still have problems with importing these variants, [file an issue](https://github.com/MattiasBuelens/web-streams-polyfill/issues).
 
 Version 4 also focuses on reducing the download size of the published npm package.
 

--- a/es5/package.json
+++ b/es5/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "web-streams-polyfill",
+  "main": "../dist/ponyfill.es5.js",
+  "module": "../dist/ponyfill.es5.mjs",
+  "types": "../types/ponyfill.d.ts"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,14 @@
         "semver": "~7.3.0",
         "source-map": "~0.6.1",
         "typescript": "~4.3.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.3.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+          "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+          "dev": true
+        }
       }
     },
     "@microsoft/api-extractor-model": {
@@ -2420,9 +2428,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
   },
   "files": [
     "dist",
+    "es5",
+    "polyfill",
     "types"
   ],
   "engines": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "rollup": "^2.56.3",
     "rollup-plugin-terser": "^7.0.2",
     "tslib": "^2.3.0",
-    "typescript": "~4.3.5",
+    "typescript": "^4.5.2",
     "wpt-runner": "^3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,38 +4,30 @@
   "description": "Web Streams, based on the WHATWG spec reference implementation",
   "main": "dist/ponyfill.js",
   "module": "dist/ponyfill.mjs",
+  "types": "types/ponyfill.d.ts",
   "exports": {
     ".": {
       "import": "./dist/ponyfill.mjs",
-      "require": "./dist/ponyfill.js"
+      "require": "./dist/ponyfill.js",
+      "types": "./types/ponyfill.d.ts"
     },
     "./es5": {
       "import": "./dist/ponyfill.es5.mjs",
-      "require": "./dist/ponyfill.es5.js"
+      "require": "./dist/ponyfill.es5.js",
+      "types": "./types/ponyfill.d.ts"
     },
-    "./polyfill": "./dist/polyfill.js",
-    "./polyfill/es5": "./dist/polyfill.es5.js",
+    "./polyfill": {
+      "default": "./dist/polyfill.js",
+      "types": "./types/polyfill.d.ts"
+    },
+    "./polyfill/es5": {
+      "default": "./dist/polyfill.es5.js",
+      "types": "./types/polyfill.d.ts"
+    },
     "./dist/*": "./dist/*",
     "./types/*": "./types/*",
     "./package": "./package.json",
     "./package.json": "./package.json"
-  },
-  "types": "types/ponyfill.d.ts",
-  "typesVersions": {
-    ">=3.6": {
-      ".": [
-        "./types/ponyfill.d.ts"
-      ],
-      "./es5": [
-        "./types/ponyfill.d.ts"
-      ],
-      "./polyfill": [
-        "./types/polyfill.d.ts"
-      ],
-      "./polyfill/es5": [
-        "./types/polyfill.d.ts"
-      ]
-    }
   },
   "scripts": {
     "test": "npm run test:types && npm run test:unit && npm run test:wpt && npm run test:bundler",

--- a/polyfill/es5/package.json
+++ b/polyfill/es5/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "web-streams-polyfill",
+  "main": "../../dist/polyfill.es5.js",
+  "types": "../../types/polyfill.d.ts"
+}

--- a/polyfill/package.json
+++ b/polyfill/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "web-streams-polyfill",
+  "main": "../dist/polyfill.js",
+  "types": "../types/polyfill.d.ts"
+}

--- a/test/unit/exports.spec.js
+++ b/test/unit/exports.spec.js
@@ -28,6 +28,36 @@ describe('package exports', () => {
   });
 });
 
+describe('fallback package exports', () => {
+  let oldGlobalReadableStream;
+  beforeEach(() => {
+    oldGlobalReadableStream = global.ReadableStream;
+  });
+  afterEach(() => {
+    global.ReadableStream = oldGlobalReadableStream;
+  });
+  it('main export works', () => {
+    const polyfill = requireUncached('../../');
+    expect(polyfill.ReadableStream).toBeDefined();
+    expect(global.ReadableStream).toBe(oldGlobalReadableStream);
+  });
+  it('es5 export works', () => {
+    const polyfill = requireUncached('../../es5');
+    expect(polyfill.ReadableStream).toBeDefined();
+    expect(global.ReadableStream).toBe(oldGlobalReadableStream);
+  });
+  it('polyfill export works', () => {
+    global.ReadableStream = undefined;
+    requireUncached('../../polyfill');
+    expect(global.ReadableStream).toBeDefined();
+  });
+  it('polyfill/es5 export works', () => {
+    global.ReadableStream = undefined;
+    requireUncached('../../polyfill/es5');
+    expect(global.ReadableStream).toBeDefined();
+  });
+});
+
 function requireUncached(module) {
   delete require.cache[require.resolve(module)];
   // eslint-disable-next-line global-require

--- a/test/unit/exports.spec.js
+++ b/test/unit/exports.spec.js
@@ -1,5 +1,3 @@
-/* eslint-disable global-require */
-
 describe('package exports', () => {
   let oldGlobalReadableStream;
   beforeEach(() => {
@@ -9,23 +7,29 @@ describe('package exports', () => {
     global.ReadableStream = oldGlobalReadableStream;
   });
   it('main export works', () => {
-    const polyfill = require('web-streams-polyfill');
+    const polyfill = requireUncached('web-streams-polyfill');
     expect(polyfill.ReadableStream).toBeDefined();
     expect(global.ReadableStream).toBe(oldGlobalReadableStream);
   });
   it('es5 export works', () => {
-    const polyfill = require('web-streams-polyfill/es5');
+    const polyfill = requireUncached('web-streams-polyfill/es5');
     expect(polyfill.ReadableStream).toBeDefined();
     expect(global.ReadableStream).toBe(oldGlobalReadableStream);
   });
   it('polyfill export works', () => {
     global.ReadableStream = undefined;
-    require('web-streams-polyfill/polyfill');
+    requireUncached('web-streams-polyfill/polyfill');
     expect(global.ReadableStream).toBeDefined();
   });
   it('polyfill/es5 export works', () => {
     global.ReadableStream = undefined;
-    require('web-streams-polyfill/polyfill/es5');
+    requireUncached('web-streams-polyfill/polyfill/es5');
     expect(global.ReadableStream).toBeDefined();
   });
 });
+
+function requireUncached(module) {
+  delete require.cache[require.resolve(module)];
+  // eslint-disable-next-line global-require
+  return require(module);
+}


### PR DESCRIPTION
In #83, we switched to using package entry points for the different variants. Unfortunately, [TypeScript 4.5 doesn't yet support this](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#beta-delta): support has been deferred to a future release. This prevents TypeScript users from importing a polyfill variant, which is not great.

This PR adds a fallback to *also* provide the variants like we did in version 3, i.e. with "sub packages" (e.g. `es5/package.json`). Modern versions of Node and modern bundlers will still pick up the new package entry points. However, tools that don't support this feature yet (like older Node versions and TypeScript 4.5) will instead find the sub packages and resolve the variant that way.