### PR TITLE
Avoid exception under PhantomJS

### DIFF
--- a/src/lib/byte-length-queuing-strategy.ts
+++ b/src/lib/byte-length-queuing-strategy.ts
@@ -7,10 +7,13 @@ import { convertQueuingStrategyInit } from './validators/queuing-strategy-init';
 const byteLengthSizeFunction = (chunk: ArrayBufferView): number => {
   return chunk.byteLength;
 };
-Object.defineProperty(byteLengthSizeFunction, 'name', {
-  value: 'size',
-  configurable: true
-});
+
+try {
+  Object.defineProperty(byteLengthSizeFunction, 'name', {
+    value: 'size',
+    configurable: true
+  });
+} catch {}
 
 /**
  * A queuing strategy that counts the number of bytes in each chunk.

--- a/src/lib/count-queuing-strategy.ts
+++ b/src/lib/count-queuing-strategy.ts
@@ -7,10 +7,14 @@ import { convertQueuingStrategyInit } from './validators/queuing-strategy-init';
 const countSizeFunction = (): 1 => {
   return 1;
 };
-Object.defineProperty(countSizeFunction, 'name', {
-  value: 'size',
-  configurable: true
-});
+
+try {
+  // To avoid exception thrown by PhantomJS
+  Object.defineProperty(countSizeFunction, 'name', {
+    value: 'size',
+    configurable: true
+  });
+} catch {}
 
 /**
  * A queuing strategy that counts the number of chunks.


### PR DESCRIPTION
Recently, I tried to import `web-streams-polyfill` and found that we could not define the property `name` of a function as configurable under PhantomJS. (REF: https://github.com/ariya/phantomjs/issues/13895)

To avoid the exception when testing under PhantomJS, I hope we can add `try...catch` to wrap them.