### PR TITLE
Fix error when trying to override a non-configurable "name" property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 🐛 Fix an error in very old browsers where `Function.name` is non-configurable. ([#112](https://github.com/MattiasBuelens/web-streams-polyfill/pull/112))
+
 ## v3.2.0 (2021-11-06)
 
 * 👎 Deprecate `WritableStreamDefaultController.abortReason` ([#102](https://github.com/MattiasBuelens/web-streams-polyfill/pull/102))

--- a/src/lib/byte-length-queuing-strategy.ts
+++ b/src/lib/byte-length-queuing-strategy.ts
@@ -7,10 +7,15 @@ import { convertQueuingStrategyInit } from './validators/queuing-strategy-init';
 const byteLengthSizeFunction = (chunk: ArrayBufferView): number => {
   return chunk.byteLength;
 };
-Object.defineProperty(byteLengthSizeFunction, 'name', {
-  value: 'size',
-  configurable: true
-});
+try {
+  Object.defineProperty(byteLengthSizeFunction, 'name', {
+    value: 'size',
+    configurable: true
+  });
+} catch {
+  // This property is non-configurable in older browsers, so ignore if this throws.
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name#browser_compatibility
+}
 
 /**
  * A queuing strategy that counts the number of bytes in each chunk.

--- a/src/lib/count-queuing-strategy.ts
+++ b/src/lib/count-queuing-strategy.ts
@@ -7,10 +7,15 @@ import { convertQueuingStrategyInit } from './validators/queuing-strategy-init';
 const countSizeFunction = (): 1 => {
   return 1;
 };
-Object.defineProperty(countSizeFunction, 'name', {
-  value: 'size',
-  configurable: true
-});
+try {
+  Object.defineProperty(countSizeFunction, 'name', {
+    value: 'size',
+    configurable: true
+  });
+} catch {
+  // This property is non-configurable in older browsers, so ignore if this throws.
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name#browser_compatibility
+}
 
 /**
  * A queuing strategy that counts the number of chunks.


### PR DESCRIPTION
In very old browsers, `Function.name` may be non-configurable ([see MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name#browser_compatibility)). When the polyfill tries to re-define this property, the `Object.defineProperty` call will throw, making the polyfill fail to load.

Fix this by catching and then ignoring this error. This `name` property is only checked by the web platform tests anyway, regular users shouldn't care too much about it being different. 🤷