### PR TITLE
Update to spec version of 18 April 2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 👓 Align with [spec version `e9355ce`](https://github.com/whatwg/streams/tree/e9355ce79925947e8eb496563d599c329769d315/) ([#115](https://github.com/MattiasBuelens/web-streams-polyfill/issues/115), [#117](https://github.com/MattiasBuelens/web-streams-polyfill/pull/117))
+
 ## v4.0.0-beta.2 (2022-04-12)
 
 * 🚀 Support calling `ReadableStream.pipeTo(writable)` and `.pipeThrough({ readable, writable })` when `writable` is a native (i.e. not polyfilled) `WritableStream`. ([#99](https://github.com/MattiasBuelens/web-streams-polyfill/pull/99), [#101](https://github.com/MattiasBuelens/web-streams-polyfill/pull/101))

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you need to support older browsers or Node versions that do not have a native
 
 ## Compliance
 
-The polyfill implements [version `4b6b93c` (25 Oct 2021)][spec-snapshot] of the streams specification.
+The polyfill implements [version `e9355ce` (18 Apr 2022)][spec-snapshot] of the streams specification.
 
 The polyfill is tested against the same [web platform tests][wpt] that are used by browsers to test their native implementations.
 It aims to pass all tests, although it allows some exceptions for practical reasons:
@@ -120,13 +120,13 @@ Thanks to these people for their work on [the original polyfill][creatorrr-polyf
 [rs-asynciterator]: https://streams.spec.whatwg.org/#rs-asynciterator
 [ws-controller-signal]: https://streams.spec.whatwg.org/#ws-default-controller-signal
 [abortcontroller-polyfill]: https://www.npmjs.com/package/abortcontroller-polyfill
-[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/4b6b93c69e531e2fe45a6ed4cb1484a7ba4eb8bb/
-[wpt]: https://github.com/web-platform-tests/wpt/tree/96ca25f0f7526282c0d47e6bf6a7edd439da1968/streams
-[wpt-bad-buffers]: https://github.com/web-platform-tests/wpt/blob/96ca25f0f7526282c0d47e6bf6a7edd439da1968/streams/readable-byte-streams/bad-buffers-and-views.any.js
+[spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/e9355ce79925947e8eb496563d599c329769d315/
+[wpt]: https://github.com/web-platform-tests/wpt/tree/6a46d9cb8d20c510a620141c721b81b460a4ee55/streams
+[wpt-bad-buffers]: https://github.com/web-platform-tests/wpt/blob/6a46d9cb8d20c510a620141c721b81b460a4ee55/streams/readable-byte-streams/bad-buffers-and-views.any.js
 [proposal-arraybuffer-transfer]: https://github.com/domenic/proposal-arraybuffer-transfer
-[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/4b6b93c69e531e2fe45a6ed4cb1484a7ba4eb8bb/reference-implementation/lib/abstract-ops/ecmascript.js#L16
+[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/e9355ce79925947e8eb496563d599c329769d315/reference-implementation/lib/abstract-ops/ecmascript.js#L16
 [issue-3]: https://github.com/MattiasBuelens/web-streams-polyfill/issues/3
-[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/96ca25f0f7526282c0d47e6bf6a7edd439da1968/streams/readable-streams/async-iterator.any.js#L24
+[wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/6a46d9cb8d20c510a620141c721b81b460a4ee55/streams/readable-streams/async-iterator.any.js#L24
 [stub-async-iterator-prototype]: https://github.com/MattiasBuelens/web-streams-polyfill/blob/v4.0.0-beta.2/src/lib/readable-stream/async-iterator.ts#L126-L134
 [wpt-rs-patched-global]: https://github.com/web-platform-tests/wpt/blob/887350c2f46def5b01c4dd1f8d2eee35dfb9c5bb/streams/readable-streams/patched-global.any.js
 [wpt-then-interception]: https://github.com/web-platform-tests/wpt/blob/cf33f00596af295ee0f207c88e23b5f8b0791307/streams/piping/then-interception.any.js

--- a/src/lib/abstract-ops/internal-methods.ts
+++ b/src/lib/abstract-ops/internal-methods.ts
@@ -2,3 +2,4 @@ export const AbortSteps = Symbol('[[AbortSteps]]');
 export const ErrorSteps = Symbol('[[ErrorSteps]]');
 export const CancelSteps = Symbol('[[CancelSteps]]');
 export const PullSteps = Symbol('[[PullSteps]]');
+export const ReleaseSteps = Symbol('[[ReleaseSteps]]');

--- a/src/lib/readable-stream/default-controller.ts
+++ b/src/lib/readable-stream/default-controller.ts
@@ -13,7 +13,7 @@ import type { ReadableStream } from '../readable-stream';
 import { IsReadableStreamLocked, ReadableStreamClose, ReadableStreamError } from '../readable-stream';
 import type { ValidatedUnderlyingSource } from './underlying-source';
 import { setFunctionName, typeIsObject } from '../helpers/miscellaneous';
-import { CancelSteps, PullSteps } from '../abstract-ops/internal-methods';
+import { CancelSteps, PullSteps, ReleaseSteps } from '../abstract-ops/internal-methods';
 import { promiseResolvedWith, uponPromise } from '../helpers/webidl';
 
 /**
@@ -131,6 +131,11 @@ export class ReadableStreamDefaultController<R> {
       ReadableStreamAddReadRequest(stream, readRequest);
       ReadableStreamDefaultControllerCallPullIfNeeded(this);
     }
+  }
+
+  /** @internal */
+  [ReleaseSteps](): void {
+    // Do nothing.
   }
 }
 

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -65,7 +65,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStreamLike<T>,
     let abortAlgorithm: () => void;
     if (signal !== undefined) {
       abortAlgorithm = () => {
-        const error = new DOMException('Aborted', 'AbortError');
+        const error = signal.reason !== undefined ? signal.reason : new DOMException('Aborted', 'AbortError');
         const actions: Array<() => Promise<void>> = [];
         if (!preventAbort) {
           actions.push(() => {

--- a/src/lib/readable-stream/tee.ts
+++ b/src/lib/readable-stream/tee.ts
@@ -185,6 +185,7 @@ export function ReadableByteStreamTee(stream: ReadableByteStreamLike): [Readable
 
   function pullWithDefaultReader() {
     if (isByobReader) {
+      // assert(reader._readIntoRequests.length === 0);
       reader.releaseLock();
       reader = stream.getReader();
       forwardReaderError(reader);
@@ -246,6 +247,7 @@ export function ReadableByteStreamTee(stream: ReadableByteStreamLike): [Readable
 
   function pullWithBYOBReader(view: ArrayBufferView, forBranch2: boolean) {
     if (!isByobReader) {
+      // assert(reader._readRequests.length === 0);
       reader.releaseLock();
       reader = stream.getReader({ mode: 'byob' });
       forwardReaderError(reader);

--- a/src/stub/assert.ts
+++ b/src/stub/assert.ts
@@ -7,11 +7,11 @@ export const AssertionError = /* @__PURE__*/ class AssertionError extends Error 
   }
 };
 
-const assert: (test: boolean, message?: string) => void =
-  DEBUG ? (test, message) => {
-    if (!test) {
-      throw new AssertionError('Assertion failed' + (message ? `: ${message}` : ''));
-    }
-  } : noop;
+function assertImpl(test: boolean, message?: string): asserts test {
+  if (!test) {
+    throw new AssertionError('Assertion failed' + (message ? `: ${message}` : ''));
+  }
+}
 
+const assert: typeof assertImpl = DEBUG ? assertImpl : noop;
 export default assert;

--- a/test/wpt/shared/exclusions.js
+++ b/test/wpt/shared/exclusions.js
@@ -12,7 +12,10 @@ const excludedTestsBase = [
   // so patching various globals *will* affect the polyfill.
   'readable-streams/patched-global.any.html',
   'piping/then-interception.any.html',
-  'transform-streams/patched-global.any.html'
+  'transform-streams/patched-global.any.html',
+  // The crash tests require creating and terminating workers and iframes.
+  'readable-streams/cross-realm-crash.window.html',
+  'readable-streams/crashtests/**'
 ];
 
 const excludedTestsNonES2018 = [


### PR DESCRIPTION
This aligns the implementation with [spec version `e9355ce` of 18 April 2022](https://streams.spec.whatwg.org/commit-snapshots/e9355ce79925947e8eb496563d599c329769d315/).

Comparison: https://github.com/whatwg/streams/compare/4b6b93c69e531e2fe45a6ed4cb1484a7ba4eb8bb...e9355ce79925947e8eb496563d599c329769d315

Fixes #115.