### PR TITLE
Fix aborting a pipe with preventCancel = true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## Unreleased
 
 * 👓 Align with [spec version `e9355ce`](https://github.com/whatwg/streams/tree/e9355ce79925947e8eb496563d599c329769d315/) ([#115](https://github.com/MattiasBuelens/web-streams-polyfill/issues/115), [#117](https://github.com/MattiasBuelens/web-streams-polyfill/pull/117))
+* 🐛 Fix `pipeTo()` never rejecting when aborting its `signal` and `preventCancel` is set to `true`. ([#118](https://github.com/MattiasBuelens/web-streams-polyfill/issues/118), [#119](https://github.com/MattiasBuelens/web-streams-polyfill/pull/119))
 
 ## v4.0.0-beta.2 (2022-04-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ## Unreleased
 
-* 👓 Align with [spec version `e9355ce`](https://github.com/whatwg/streams/tree/e9355ce79925947e8eb496563d599c329769d315/) ([#115](https://github.com/MattiasBuelens/web-streams-polyfill/issues/115), [#117](https://github.com/MattiasBuelens/web-streams-polyfill/pull/117))
+* 👓 Align with [spec version `e9355ce`](https://github.com/whatwg/streams/tree/e9355ce79925947e8eb496563d599c329769d315/). ([#115](https://github.com/MattiasBuelens/web-streams-polyfill/issues/115), [#117](https://github.com/MattiasBuelens/web-streams-polyfill/pull/117))
 * 🐛 Fix `pipeTo()` never rejecting when aborting its `signal` and `preventCancel` is set to `true`. ([#118](https://github.com/MattiasBuelens/web-streams-polyfill/issues/118), [#119](https://github.com/MattiasBuelens/web-streams-polyfill/pull/119))
 
 ## v4.0.0-beta.2 (2022-04-12)

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -148,10 +148,10 @@ export function ReadableStreamPipeTo<T>(source: ReadableStreamLike<T>,
           if (destCloseRequested || destState === 'closed') {
             return promiseResolvedWith(undefined);
           }
-          if (destState === 'errored') {
+          if (destState === 'erroring' || destState === 'errored') {
             return promiseRejectedWith(destStoredError);
           }
-          assert(destState === 'writable' || destState === 'erroring');
+          assert(destState === 'writable');
           destCloseRequested = true;
           return writer.close();
         }, false, undefined);
@@ -189,7 +189,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStreamLike<T>,
         return null;
       }
       // Errors must be propagated backward
-      assert(!IsWritableStream(dest) || dest._state === 'errored');
+      assert(!IsWritableStream(dest) || dest._state === 'erroring' || dest._state === 'errored');
       destState = 'errored';
       destStoredError = storedError;
       if (!preventCancel) {
@@ -220,7 +220,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStreamLike<T>,
     if (sourceState === 'errored') {
       // Errors must be propagated forward
       handleSourceError(sourceStoredError);
-    } else if (destState === 'errored') {
+    } else if (destState === 'erroring' || destState === 'errored') {
       // Errors must be propagated backward
       handleDestError(destStoredError);
     } else if (sourceState === 'closed') {

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -285,7 +285,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStreamLike<T>,
       }
 
       function onStart(): null {
-        if (currentWrite !== undefined) {
+        if (destState === 'writable' && !destCloseRequested) {
           uponFulfillment(waitForWritesToFinish(), doTheRest);
         } else {
           doTheRest();

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -162,7 +162,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStreamLike<T>,
     }
 
     function handleSourceError(storedError: any): null {
-      if (released) {
+      if (shuttingDown) {
         return null;
       }
       // Errors must be propagated forward
@@ -178,7 +178,9 @@ export function ReadableStreamPipeTo<T>(source: ReadableStreamLike<T>,
     }
 
     function handleDestClose(): null {
-      assert(!released);
+      if (released) {
+        return null;
+      }
       assert(!IsWritableStream(dest) || dest._state === 'closed');
       destState = 'closed';
       return null;

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -58,7 +58,7 @@ export function ReadableStreamPipeTo<T>(source: ReadableStreamLike<T>,
   });
 
   // This is used to keep track of the spec's requirement that we wait for ongoing writes during shutdown.
-  let currentWrite: Promise<unknown> | undefined;
+  let currentWrite: Promise<unknown> = Promise.resolve(undefined);
 
   return newPromise((resolve, reject) => {
     let abortAlgorithm: () => void;

--- a/test/unit/util/delay.js
+++ b/test/unit/util/delay.js
@@ -1,0 +1,3 @@
+exports.delay = function (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+};

--- a/test/wpt/shared/exclusions.js
+++ b/test/wpt/shared/exclusions.js
@@ -25,11 +25,6 @@ const excludedTestsNonES2018 = [
 ];
 
 const skippedTests = {
-  'piping/error-propagation-backward.any.html': [
-    // This test cheats: pipeTo() releases the reader's lock while there's still a pending read().
-    // The polyfill cannot do this, because it uses the reader.releaseLock() public API.
-    'Errors must be propagated backward: becomes errored after piping; preventCancel = true'
-  ]
 };
 
 const ignoredFailuresBase = {


### PR DESCRIPTION
Some of the changes in #99 broke `preventCancel`. This fixes that.

Fixes #118.