### PR TITLE
Use native DOMException in Node 15 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* Use native `DOMException` on Node 15 and higher. ([#109](https://github.com/MattiasBuelens/web-streams-polyfill/issues/109), [#110](https://github.com/MattiasBuelens/web-streams-polyfill/pull/120))
+
 ## v4.0.0-beta.3 (2022-05-24)
 
 * 👓 Align with [spec version `e9355ce`](https://github.com/whatwg/streams/tree/e9355ce79925947e8eb496563d599c329769d315/). ([#115](https://github.com/MattiasBuelens/web-streams-polyfill/issues/115), [#117](https://github.com/MattiasBuelens/web-streams-polyfill/pull/117))

--- a/src/stub/dom-exception.ts
+++ b/src/stub/dom-exception.ts
@@ -13,6 +13,9 @@ function isDOMExceptionConstructor(ctor: unknown): ctor is DOMExceptionConstruct
   if (!(typeof ctor === 'function' || typeof ctor === 'object')) {
     return false;
   }
+  if ((ctor as DOMExceptionConstructor).name !== 'DOMException') {
+    return false;
+  }
   try {
     new (ctor as DOMExceptionConstructor)();
     return true;

--- a/src/stub/dom-exception.ts
+++ b/src/stub/dom-exception.ts
@@ -21,14 +21,23 @@ function isDOMExceptionConstructor(ctor: unknown): ctor is DOMExceptionConstruct
   }
 }
 
-// - Web browsers
-// - Node 18 and higher (https://github.com/nodejs/node/commit/e4b1fb5e6422c1ff151234bb9de792d45dd88d87)
+/**
+ * Support:
+ * - Web browsers
+ * - Node 18 and higher (https://github.com/nodejs/node/commit/e4b1fb5e6422c1ff151234bb9de792d45dd88d87)
+ */
 function getFromGlobal(): DOMExceptionConstructor | undefined {
   const ctor = globals?.DOMException;
   return isDOMExceptionConstructor(ctor) ? ctor : undefined;
 }
 
-// - Node 15 and higher (https://github.com/nodejs/node/commit/eee522ac29864a55a8bc6686e6b38e93270aa1ca)
+/**
+ * Support:
+ * - Node 15 and higher (https://github.com/nodejs/node/commit/eee522ac29864a55a8bc6686e6b38e93270aa1ca)
+ *
+ * Original from node-domexception by Jimmy Wärting (license: MIT)
+ * https://www.npmjs.com/package/node-domexception
+ */
 function getFromMessageChannel(): DOMExceptionConstructor | undefined {
   try {
     const port = new MessageChannel().port1;
@@ -41,7 +50,10 @@ function getFromMessageChannel(): DOMExceptionConstructor | undefined {
   }
 }
 
-// - Other platforms
+/**
+ * Support:
+ * - All platforms
+ */
 function createPolyfill(): DOMExceptionConstructor {
   // eslint-disable-next-line no-shadow
   const ctor = function DOMException(this: DOMException, message?: string, name?: string) {

--- a/src/stub/dom-exception.ts
+++ b/src/stub/dom-exception.ts
@@ -1,5 +1,6 @@
 /// <reference types="node" />
 import { globals } from '../globals';
+import { setFunctionName } from '../lib/helpers/miscellaneous';
 
 interface DOMException extends Error {
   name: string;
@@ -50,6 +51,7 @@ function createPolyfill(): DOMExceptionConstructor {
       Error.captureStackTrace(this, this.constructor);
     }
   } as any;
+  setFunctionName(ctor, 'DOMException');
   ctor.prototype = Object.create(Error.prototype);
   Object.defineProperty(ctor.prototype, 'constructor', { value: ctor, writable: true, configurable: true });
   return ctor;

--- a/src/stub/dom-exception.ts
+++ b/src/stub/dom-exception.ts
@@ -39,15 +39,21 @@ function getFromGlobal(): DOMExceptionConstructor | undefined {
  * https://www.npmjs.com/package/node-domexception
  */
 function getFromMessageChannel(): DOMExceptionConstructor | undefined {
+  let port: MessagePort;
+  let buffer: ArrayBuffer;
   try {
-    const port = new MessageChannel().port1;
-    const buffer = new ArrayBuffer(0);
-    port.postMessage(buffer, [buffer, buffer]);
+    port = new MessageChannel().port1;
+    buffer = new ArrayBuffer(0);
+  } catch {
     return undefined;
+  }
+  try {
+    port.postMessage(buffer, [buffer, buffer]);
   } catch (err) {
     const ctor = (err as DOMException).constructor;
     return isDOMExceptionConstructor(ctor) ? ctor : undefined;
   }
+  return undefined;
 }
 
 /**

--- a/src/stub/native.ts
+++ b/src/stub/native.ts
@@ -1,3 +1,0 @@
-/// <reference lib="dom" />
-export const NativeDOMException: typeof DOMException | undefined =
-  typeof DOMException !== 'undefined' ? DOMException : undefined;


### PR DESCRIPTION
This tries to retrieve the native `DOMException` constructor using a `MessageChannel`, which is available as a global as of Node 15 (https://github.com/nodejs/node/commit/eee522ac29864a55a8bc6686e6b38e93270aa1ca).

Fixes #109.