### PR TITLE
Transfer buffers passed to `ReadableStreamBYOBReader.read(view)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   * Added `Transformer.cancel` method, which is called when the readable side of a `TransformStream` is cancelled or when its writable side is aborted.
   * Added `min` option to `ReadableStreamBYOBReader.read(view, options)`.
   * Added support for `AbortSignal.reason` when aborting a pipe.
+* 🚀 Buffers passed to `ReadableStreamBYOBReader.read(view)` will now be correctly [transferred](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer#transferring_arraybuffers)
+  if either `ArrayBuffer.prototype.transfer()` or `structuredClone()` is available. ([#136](https://github.com/MattiasBuelens/web-streams-polyfill/pull/135))
 * 🐛 Prevent [warnings from Bluebird](http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it) about a promise being created within a handler but not being returned from a handler. ([#131](https://github.com/MattiasBuelens/web-streams-polyfill/pull/131))
 * 🏠 Improve internal `DOMException` polyfill. ([#133](https://github.com/MattiasBuelens/web-streams-polyfill/pull/133))
 

--- a/README.md
+++ b/README.md
@@ -66,15 +66,15 @@ The `polyfill/es2018` and `ponyfill/es2018` variants work in any ES2018-compatib
 
 [`WritableStreamDefaultController.signal`][ws-controller-signal] is available in all variants, but requires a global `AbortController` constructor. If necessary, consider using a polyfill such as [abortcontroller-polyfill].
 
+[Reading with a BYOB reader][mdn-byob-read] is available in all variants, but requires `ArrayBuffer.prototype.transfer()` or `structuredClone()` to exist in order to correctly transfer the given view's buffer. If not available, then the buffer won't be transferred during the read.
+
 ## Compliance
 
 The polyfill implements [version `4dc123a` (13 Nov 2023)][spec-snapshot] of the streams specification.
 
 The polyfill is tested against the same [web platform tests][wpt] that are used by browsers to test their native implementations.
 The polyfill aims to pass all tests, although it allows some exceptions for practical reasons:
-* The `es2018` variant passes all of the tests, except for the ["bad buffers and views" tests for readable byte streams][wpt-bad-buffers].
-  These tests require the implementation to synchronously transfer the contents of an `ArrayBuffer`, which is not yet possible from JavaScript (although there is a [proposal][proposal-arraybuffer-transfer] to make it possible).
-  The reference implementation "cheats" on these tests [by making a copy instead][ref-impl-transferarraybuffer], but that is unacceptable for the polyfill's performance ([#3][issue-3]).
+* The `es2018` variant passes all of the tests.
 * The `es6` variant passes the same tests as the `es2018` variant, except for the [test for the prototype of `ReadableStream`'s async iterator][wpt-async-iterator-prototype].
   Retrieving the correct `%AsyncIteratorPrototype%` requires using an async generator (`async function* () {}`), which is invalid syntax before ES2018.
   Instead, the polyfill [creates its own version][stub-async-iterator-prototype] which is functionally equivalent to the real prototype.
@@ -103,12 +103,9 @@ Thanks to these people for their work on [the original polyfill][creatorrr-polyf
 [rs-asynciterator]: https://streams.spec.whatwg.org/#rs-asynciterator
 [ws-controller-signal]: https://streams.spec.whatwg.org/#ws-default-controller-signal
 [abortcontroller-polyfill]: https://www.npmjs.com/package/abortcontroller-polyfill
+[mdn-byob-read]: https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBReader/read
 [spec-snapshot]: https://streams.spec.whatwg.org/commit-snapshots/4dc123a6e7f7ba89a8c6a7975b021156f39cab52/
 [wpt]: https://github.com/web-platform-tests/wpt/tree/2a298b616b7c865917d7198a287310881cbfdd8d/streams
-[wpt-bad-buffers]: https://github.com/web-platform-tests/wpt/blob/2a298b616b7c865917d7198a287310881cbfdd8d/streams/readable-byte-streams/bad-buffers-and-views.any.js
-[proposal-arraybuffer-transfer]: https://github.com/domenic/proposal-arraybuffer-transfer
-[ref-impl-transferarraybuffer]: https://github.com/whatwg/streams/blob/4dc123a6e7f7ba89a8c6a7975b021156f39cab52/reference-implementation/lib/abstract-ops/ecmascript.js#L18
-[issue-3]: https://github.com/MattiasBuelens/web-streams-polyfill/issues/3
 [wpt-async-iterator-prototype]: https://github.com/web-platform-tests/wpt/blob/2a298b616b7c865917d7198a287310881cbfdd8d/streams/readable-streams/async-iterator.any.js#L24
 [stub-async-iterator-prototype]: https://github.com/MattiasBuelens/web-streams-polyfill/blob/v2.0.0/src/target/es5/stub/async-iterator-prototype.ts
 [creatorrr-polyfill]: https://github.com/creatorrr/web-streams-polyfill

--- a/src/lib/abstract-ops/ecmascript.ts
+++ b/src/lib/abstract-ops/ecmascript.ts
@@ -2,6 +2,10 @@ import { reflectCall } from 'lib/helpers/webidl';
 import { typeIsObject } from '../helpers/miscellaneous';
 import assert from '../../stub/assert';
 
+declare global {
+  function structuredClone<T>(value: T, options: { transfer: ArrayBuffer[] }): T;
+}
+
 export function CreateArrayFromList<T extends any[]>(elements: T): T {
   // We use arrays to represent lists, so this is basically a no-op.
   // Do a slice though just in case we happen to depend on the unique-ness.
@@ -16,21 +20,26 @@ export function CopyDataBlockBytes(dest: ArrayBuffer,
   new Uint8Array(dest).set(new Uint8Array(src, srcOffset, n), destOffset);
 }
 
-// Not implemented correctly
-export function TransferArrayBuffer<T extends ArrayBufferLike>(O: T): T {
-  return O;
-}
+export let TransferArrayBuffer = <T extends ArrayBufferLike>(O: T): T => {
+  if (typeof structuredClone === 'function') {
+    TransferArrayBuffer = buffer => structuredClone(buffer, { transfer: [buffer] });
+  } else {
+    // Not implemented correctly
+    TransferArrayBuffer = buffer => buffer;
+  }
+  return TransferArrayBuffer(O);
+};
 
 // Not implemented correctly
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function CanTransferArrayBuffer(O: ArrayBufferLike): boolean {
-  return true;
+  return !IsDetachedBuffer(O);
 }
 
 // Not implemented correctly
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function IsDetachedBuffer(O: ArrayBufferLike): boolean {
-  return false;
+  return O.byteLength === 0;
 }
 
 export function ArrayBufferSlice(buffer: ArrayBufferLike, begin: number, end: number): ArrayBufferLike {

--- a/src/lib/abstract-ops/ecmascript.ts
+++ b/src/lib/abstract-ops/ecmascript.ts
@@ -20,7 +20,7 @@ export function CopyDataBlockBytes(dest: ArrayBuffer,
   new Uint8Array(dest).set(new Uint8Array(src, srcOffset, n), destOffset);
 }
 
-export let TransferArrayBuffer = <T extends ArrayBufferLike>(O: T): T => {
+export let TransferArrayBuffer = (O: ArrayBuffer): ArrayBuffer => {
   if (typeof structuredClone === 'function') {
     TransferArrayBuffer = buffer => structuredClone(buffer, { transfer: [buffer] });
   } else {
@@ -32,17 +32,17 @@ export let TransferArrayBuffer = <T extends ArrayBufferLike>(O: T): T => {
 
 // Not implemented correctly
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function CanTransferArrayBuffer(O: ArrayBufferLike): boolean {
+export function CanTransferArrayBuffer(O: ArrayBuffer): boolean {
   return !IsDetachedBuffer(O);
 }
 
 // Not implemented correctly
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function IsDetachedBuffer(O: ArrayBufferLike): boolean {
+export function IsDetachedBuffer(O: ArrayBuffer): boolean {
   return O.byteLength === 0;
 }
 
-export function ArrayBufferSlice(buffer: ArrayBufferLike, begin: number, end: number): ArrayBufferLike {
+export function ArrayBufferSlice(buffer: ArrayBuffer, begin: number, end: number): ArrayBuffer {
   // ArrayBuffer.prototype.slice is not available on IE10
   // https://www.caniuse.com/mdn-javascript_builtins_arraybuffer_slice
   if (buffer.slice) {

--- a/src/lib/abstract-ops/miscellaneous.ts
+++ b/src/lib/abstract-ops/miscellaneous.ts
@@ -1,5 +1,6 @@
 import NumberIsNaN from '../../stub/number-isnan';
 import { ArrayBufferSlice } from './ecmascript';
+import type { NonShared } from '../helpers/array-buffer-view';
 
 export function IsNonNegativeNumber(v: number): boolean {
   if (typeof v !== 'number') {
@@ -17,7 +18,7 @@ export function IsNonNegativeNumber(v: number): boolean {
   return true;
 }
 
-export function CloneAsUint8Array(O: ArrayBufferView): Uint8Array {
+export function CloneAsUint8Array(O: NonShared<ArrayBufferView>): NonShared<Uint8Array> {
   const buffer = ArrayBufferSlice(O.buffer, O.byteOffset, O.byteOffset + O.byteLength);
-  return new Uint8Array(buffer);
+  return new Uint8Array(buffer) as NonShared<Uint8Array>;
 }

--- a/src/lib/helpers/array-buffer-view.ts
+++ b/src/lib/helpers/array-buffer-view.ts
@@ -7,12 +7,14 @@ export type TypedArray =
   | Int32Array
   | Uint32Array
   | Float32Array
-  | Float64Array
-  | BigInt64Array
-  | BigUint64Array;
+  | Float64Array;
+
+export type NonShared<T extends ArrayBufferView> = T & {
+  buffer: ArrayBuffer;
+}
 
 export interface ArrayBufferViewConstructor<T extends ArrayBufferView = ArrayBufferView> {
-  new(buffer: ArrayBufferLike, byteOffset: number, length?: number): T;
+  new(buffer: ArrayBuffer, byteOffset: number, length?: number): T;
 
   readonly prototype: T;
 }

--- a/src/lib/readable-stream.ts
+++ b/src/lib/readable-stream.ts
@@ -68,12 +68,13 @@ import { convertPipeOptions } from './validators/pipe-options';
 import type { ReadableWritablePair } from './readable-stream/readable-writable-pair';
 import { convertReadableWritablePair } from './validators/readable-writable-pair';
 import type { ReadableStreamDefaultReaderLike, ReadableStreamLike } from './readable-stream/readable-stream-like';
+import type { NonShared } from './helpers/array-buffer-view';
 
 export type DefaultReadableStream<R = any> = ReadableStream<R> & {
   _readableStreamController: ReadableStreamDefaultController<R>
 };
 
-export type ReadableByteStream = ReadableStream<Uint8Array> & {
+export type ReadableByteStream = ReadableStream<NonShared<Uint8Array>> & {
   _readableStreamController: ReadableByteStreamController
 };
 

--- a/src/lib/readable-stream/byob-reader.ts
+++ b/src/lib/readable-stream/byob-reader.ts
@@ -22,7 +22,7 @@ import type {
   ValidatedReadableStreamBYOBReaderReadOptions
 } from './reader-options';
 import { convertByobReadOptions } from '../validators/reader-options';
-import { isDataView, type TypedArray } from '../helpers/array-buffer-view';
+import { isDataView, type NonShared, type TypedArray } from '../helpers/array-buffer-view';
 
 /**
  * A result returned by {@link ReadableStreamBYOBReader.read}.
@@ -40,13 +40,15 @@ export type ReadableStreamBYOBReadResult<T extends ArrayBufferView> = {
 // Abstract operations for the ReadableStream.
 
 export function AcquireReadableStreamBYOBReader(stream: ReadableByteStream): ReadableStreamBYOBReader {
-  return new ReadableStreamBYOBReader(stream);
+  return new ReadableStreamBYOBReader(stream as ReadableStream<Uint8Array>);
 }
 
 // ReadableStream API exposed for controllers.
 
-export function ReadableStreamAddReadIntoRequest<T extends ArrayBufferView>(stream: ReadableByteStream,
-                                                                            readIntoRequest: ReadIntoRequest<T>): void {
+export function ReadableStreamAddReadIntoRequest<T extends NonShared<ArrayBufferView>>(
+  stream: ReadableByteStream,
+  readIntoRequest: ReadIntoRequest<T>
+): void {
   assert(IsReadableStreamBYOBReader(stream._reader));
   assert(stream._state === 'readable' || stream._state === 'closed');
 
@@ -88,7 +90,7 @@ export function ReadableStreamHasBYOBReader(stream: ReadableByteStream): boolean
 
 // Readers
 
-export interface ReadIntoRequest<T extends ArrayBufferView> {
+export interface ReadIntoRequest<T extends NonShared<ArrayBufferView>> {
   _chunkSteps(chunk: T): void;
 
   _closeSteps(chunk: T | undefined): void;
@@ -167,7 +169,7 @@ export class ReadableStreamBYOBReader {
     view: T,
     options?: ReadableStreamBYOBReaderReadOptions
   ): Promise<ReadableStreamBYOBReadResult<T>>;
-  read<T extends ArrayBufferView>(
+  read<T extends NonShared<ArrayBufferView>>(
     view: T,
     rawOptions: ReadableStreamBYOBReaderReadOptions | null | undefined = {}
   ): Promise<ReadableStreamBYOBReadResult<T>> {
@@ -277,7 +279,7 @@ export function IsReadableStreamBYOBReader(x: any): x is ReadableStreamBYOBReade
   return x instanceof ReadableStreamBYOBReader;
 }
 
-export function ReadableStreamBYOBReaderRead<T extends ArrayBufferView>(
+export function ReadableStreamBYOBReaderRead<T extends NonShared<ArrayBufferView>>(
   reader: ReadableStreamBYOBReader,
   view: T,
   min: number,

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -643,22 +643,25 @@ export function ReadableByteStreamControllerPullInto<T extends NonShared<ArrayBu
   const ctor = view.constructor as ArrayBufferViewConstructor<T>;
   const elementSize = arrayBufferViewElementSize(ctor);
 
+  const { byteOffset, byteLength } = view;
+
   const minimumFill = min * elementSize;
-  assert(minimumFill >= elementSize && minimumFill <= view.byteLength);
+  assert(minimumFill >= elementSize && minimumFill <= byteLength);
   assert(minimumFill % elementSize === 0);
 
-  // try {
-  const buffer = TransferArrayBuffer(view.buffer);
-  // } catch (e) {
-  //   readIntoRequest._errorSteps(e);
-  //   return;
-  // }
+  let buffer: ArrayBuffer;
+  try {
+    buffer = TransferArrayBuffer(view.buffer);
+  } catch (e) {
+    readIntoRequest._errorSteps(e);
+    return;
+  }
 
   const pullIntoDescriptor: BYOBPullIntoDescriptor<T> = {
     buffer,
     bufferByteLength: buffer.byteLength,
-    byteOffset: view.byteOffset,
-    byteLength: view.byteLength,
+    byteOffset,
+    byteLength,
     bytesFilled: 0,
     minimumFill,
     elementSize,
@@ -866,9 +869,7 @@ export function ReadableByteStreamControllerEnqueue(
     return;
   }
 
-  const buffer = chunk.buffer;
-  const byteOffset = chunk.byteOffset;
-  const byteLength = chunk.byteLength;
+  const { buffer, byteOffset, byteLength } = chunk;
   if (IsDetachedBuffer(buffer)) {
     throw new TypeError('chunk\'s buffer is detached and so cannot be enqueued');
   }

--- a/src/lib/readable-stream/tee.ts
+++ b/src/lib/readable-stream/tee.ts
@@ -39,6 +39,7 @@ import {
 } from './byte-stream-controller';
 import { CreateArrayFromList } from '../abstract-ops/ecmascript';
 import { CloneAsUint8Array } from '../abstract-ops/miscellaneous';
+import type { NonShared } from '../helpers/array-buffer-view';
 
 export function ReadableStreamTee<R>(stream: ReadableStream<R>,
                                      cloneForBranch2: boolean): [ReadableStream<R>, ReadableStream<R>] {
@@ -178,7 +179,7 @@ export function ReadableByteStreamTee(stream: ReadableByteStream): [ReadableByte
   assert(IsReadableStream(stream));
   assert(IsReadableByteStreamController(stream._readableStreamController));
 
-  let reader: ReadableStreamReader<Uint8Array> = AcquireReadableStreamDefaultReader(stream);
+  let reader: ReadableStreamReader<NonShared<Uint8Array>> = AcquireReadableStreamDefaultReader(stream);
   let reading = false;
   let readAgainForBranch1 = false;
   let readAgainForBranch2 = false;
@@ -194,7 +195,7 @@ export function ReadableByteStreamTee(stream: ReadableByteStream): [ReadableByte
     resolveCancelPromise = resolve;
   });
 
-  function forwardReaderError(thisReader: ReadableStreamReader<Uint8Array>) {
+  function forwardReaderError(thisReader: ReadableStreamReader<NonShared<Uint8Array>>) {
     uponRejection(thisReader._closedPromise, r => {
       if (thisReader !== reader) {
         return null;
@@ -217,7 +218,7 @@ export function ReadableByteStreamTee(stream: ReadableByteStream): [ReadableByte
       forwardReaderError(reader);
     }
 
-    const readRequest: ReadRequest<Uint8Array> = {
+    const readRequest: ReadRequest<NonShared<Uint8Array>> = {
       _chunkSteps: chunk => {
         // This needs to be delayed a microtask because it takes at least a microtask to detect errors (using
         // reader._closedPromise below), and we want errors in stream to error both branches immediately. We cannot let
@@ -279,8 +280,8 @@ export function ReadableByteStreamTee(stream: ReadableByteStream): [ReadableByte
     ReadableStreamDefaultReaderRead(reader, readRequest);
   }
 
-  function pullWithBYOBReader(view: ArrayBufferView, forBranch2: boolean) {
-    if (IsReadableStreamDefaultReader<Uint8Array>(reader)) {
+  function pullWithBYOBReader(view: NonShared<ArrayBufferView>, forBranch2: boolean) {
+    if (IsReadableStreamDefaultReader<NonShared<Uint8Array>>(reader)) {
       assert(reader._readRequests.length === 0);
       ReadableStreamReaderGenericRelease(reader);
 
@@ -291,7 +292,7 @@ export function ReadableByteStreamTee(stream: ReadableByteStream): [ReadableByte
     const byobBranch = forBranch2 ? branch2 : branch1;
     const otherBranch = forBranch2 ? branch1 : branch2;
 
-    const readIntoRequest: ReadIntoRequest<ArrayBufferView> = {
+    const readIntoRequest: ReadIntoRequest<NonShared<ArrayBufferView>> = {
       _chunkSteps: chunk => {
         // This needs to be delayed a microtask because it takes at least a microtask to detect errors (using
         // reader._closedPromise below), and we want errors in stream to error both branches immediately. We cannot let

--- a/test/wpt/shared/exclusions.js
+++ b/test/wpt/shared/exclusions.js
@@ -1,8 +1,5 @@
 const excludedTestsBase = [
-  // We cannot polyfill TransferArrayBuffer yet, so disable tests for detached array buffers
-  // See https://github.com/MattiasBuelens/web-streams-polyfill/issues/3
-  'readable-byte-streams/bad-buffers-and-views.any.html',
-  'readable-byte-streams/enqueue-with-detached-buffer.window.html',
+  // We cannot detect non-transferability, and Node's WebAssembly.Memory is also not marked as such.
   'readable-byte-streams/non-transferable-buffers.any.html',
   // Disable tests for different size functions per realm, since they need a working <iframe>
   'queuing-strategies-size-function-per-global.window.html',
@@ -32,14 +29,11 @@ const excludedTestsNonES2018 = [
 ];
 
 const ignoredFailuresBase = {
-  // We cannot transfer byobRequest.view.buffer after respond() or enqueue()
-  'readable-byte-streams/general.any.html': [
-    'ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple respond() calls',
-    'ReadableStream with byte source: read(view) with Uint32Array, then fill it by multiple enqueue() calls'
-  ],
-  // Same thing: the enqueued chunk will have the same buffer as branch1's chunk
-  'readable-byte-streams/tee.any.html': [
-    'ReadableStream teeing with byte source: chunks should be cloned for each branch'
+  // We cannot distinguish between a zero-length ArrayBuffer and a detached ArrayBuffer,
+  // so we incorrectly throw a TypeError instead of a RangeError
+  'readable-byte-streams/bad-buffers-and-views.any.html': [
+    'ReadableStream with byte source: respondWithNewView() throws if the supplied view\'s buffer is zero-length ' +
+    '(in the closed state)'
   ]
 };
 


### PR DESCRIPTION
We now have [`ArrayBuffer.prototype.transfer()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer) and [`structuredClone()`](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone), so we can finally *properly* transfer the buffers passed to `read(view)` like the specification wants! 🎉 