### PR TITLE
Improve release CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,14 +21,23 @@ jobs:
         with:
           ref: ${{ github.event.release.target_commitish }}
       - name: Validate and extract release information
+        id: release
         uses: manovotny/github-releases-for-automated-package-publishing-action@v2.0.1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
+          always-auth: true
           cache: 'npm'
       - run: npm ci
-      - run: npm publish --provenance
+      - name: Publish latest version
+        if: steps.release.outputs.tag == ''
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish next version
+        if: steps.release.outputs.tag != ''
+        run: npm publish --provenance --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ jobs:
   # Publish job
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         node-version: [ 20 ]
@@ -24,6 +27,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,6 @@ on:
   # Runs whenever a new release is created in GitHub
   release:
     types: [ created ]
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
 
 jobs:
   # Publish job
@@ -20,6 +18,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.target_commitish }}
+      - name: Validate and extract release information
+        uses: manovotny/github-releases-for-automated-package-publishing-action@v2.0.1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
* Publish new releases to npm [with provenance](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions)
* [Validate release information](https://github.com/marketplace/actions/github-releases-for-automated-package-publishing) before publishing
* Publish prereleases to "next" tag on npm