### PR TITLE
Optimize `ReadableStream.from()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   * When using TypeScript, version 4.7 or higher is now required. Additionally, [`moduleResolution`](https://www.typescriptlang.org/tsconfig#moduleResolution) must be set to `"node16"`, `"nodenext"` or `"bundler"`.
 * 🚀 Support [importing as ESM in Node](https://nodejs.org/api/esm.html).
 * 💅 Minify all code in the published package, to reduce the download size.
+* 💅 Rework `ReadableStream.from()` implementation to avoid depending on `async function*` down-leveling for ES5. ([#144](https://github.com/MattiasBuelens/web-streams-polyfill/pull/144))
 
 | v3 import | v4 import | description |
 | --- | --- | --- |

--- a/src/lib/abstract-ops/ecmascript.ts
+++ b/src/lib/abstract-ops/ecmascript.ts
@@ -168,14 +168,3 @@ export function IteratorNext<T>(iteratorRecord: AsyncIteratorRecord<T>): Promise
   return result;
 }
 
-export function IteratorComplete<TReturn>(
-  iterResult: IteratorResult<unknown, TReturn>
-): iterResult is IteratorReturnResult<TReturn> {
-  assert(typeIsObject(iterResult));
-  return Boolean(iterResult.done);
-}
-
-export function IteratorValue<T>(iterResult: IteratorYieldResult<T>): T {
-  assert(typeIsObject(iterResult));
-  return iterResult.value;
-}

--- a/src/lib/abstract-ops/ecmascript.ts
+++ b/src/lib/abstract-ops/ecmascript.ts
@@ -1,4 +1,10 @@
-import { reflectCall } from 'lib/helpers/webidl';
+import {
+  PerformPromiseThen,
+  promiseRejectedWith,
+  promiseResolve,
+  promiseResolvedWith,
+  reflectCall
+} from 'lib/helpers/webidl';
 import { typeIsObject } from '../helpers/miscellaneous';
 import assert from '../../stub/assert';
 
@@ -79,9 +85,11 @@ export function GetMethod<T, K extends MethodName<T>>(receiver: T, prop: K): T[K
   return func;
 }
 
+export type SyncOrAsync<T> = T | Promise<T>;
+
 export interface SyncIteratorRecord<T> {
   iterator: Iterator<T>,
-  nextMethod: Iterator<T>['next'],
+  nextMethod: () => SyncOrAsync<IteratorResult<SyncOrAsync<T>>>,
   done: boolean;
 }
 
@@ -93,21 +101,55 @@ export interface AsyncIteratorRecord<T> {
 
 export type SyncOrAsyncIteratorRecord<T> = SyncIteratorRecord<T> | AsyncIteratorRecord<T>;
 
-export function CreateAsyncFromSyncIterator<T>(syncIteratorRecord: SyncIteratorRecord<T>): AsyncIteratorRecord<T> {
-  // Instead of re-implementing CreateAsyncFromSyncIterator and %AsyncFromSyncIteratorPrototype%,
-  // we use yield* inside an async generator function to achieve the same result.
-
-  // Wrap the sync iterator inside a sync iterable, so we can use it with yield*.
-  const syncIterable = {
-    [Symbol.iterator]: () => syncIteratorRecord.iterator
+export function CreateAsyncFromSyncIterator<T>(
+  syncIteratorRecord: SyncIteratorRecord<SyncOrAsync<T>>
+): AsyncIteratorRecord<T> {
+  const asyncIterator: AsyncIterator<T> = {
+    // https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.next
+    next() {
+      let result;
+      try {
+        result = IteratorNext(syncIteratorRecord);
+      } catch (e) {
+        return promiseRejectedWith(e);
+      }
+      return AsyncFromSyncIteratorContinuation(result);
+    },
+    // https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.return
+    return(value: any) {
+      let result;
+      try {
+        const returnMethod = GetMethod(syncIteratorRecord.iterator, 'return');
+        if (returnMethod === undefined) {
+          return promiseResolvedWith({ done: true, value });
+        }
+        // Note: ReadableStream.from() always calls return() with a value.
+        result = reflectCall(returnMethod, syncIteratorRecord.iterator, [value]);
+      } catch (e) {
+        return promiseRejectedWith(e);
+      }
+      if (!typeIsObject(result)) {
+        return promiseRejectedWith(new TypeError('The iterator.return() method must return an object'));
+      }
+      return AsyncFromSyncIteratorContinuation(result);
+    }
+    // Note: throw() is never used by the Streams spec.
   };
-  // Create an async generator function and immediately invoke it.
-  const asyncIterator = (async function* () {
-    return yield* syncIterable;
-  }());
   // Return as an async iterator record.
   const nextMethod = asyncIterator.next;
   return { iterator: asyncIterator, nextMethod, done: false };
+}
+
+// https://tc39.es/ecma262/#sec-asyncfromsynciteratorcontinuation
+function AsyncFromSyncIteratorContinuation<T>(result: IteratorResult<SyncOrAsync<T>>): Promise<IteratorResult<T>> {
+  try {
+    const done = result.done;
+    const value = result.value;
+    const valueWrapper = promiseResolve(value);
+    return PerformPromiseThen(valueWrapper, v => ({ done, value: v }));
+  } catch (e) {
+    return promiseRejectedWith(e);
+  }
 }
 
 // Aligns with core-js/modules/es.symbol.async-iterator.js
@@ -160,7 +202,11 @@ function GetIterator<T>(
 
 export { GetIterator };
 
-export function IteratorNext<T>(iteratorRecord: AsyncIteratorRecord<T>): Promise<IteratorResult<T>> {
+export function IteratorNext<T>(iteratorRecord: SyncIteratorRecord<T>): IteratorResult<T>;
+export function IteratorNext<T>(iteratorRecord: AsyncIteratorRecord<T>): Promise<IteratorResult<T>>;
+export function IteratorNext<T>(
+  iteratorRecord: SyncOrAsyncIteratorRecord<T>
+): SyncOrAsync<IteratorResult<SyncOrAsync<T>>> {
   const result = reflectCall(iteratorRecord.nextMethod, iteratorRecord.iterator, []);
   if (!typeIsObject(result)) {
     throw new TypeError('The iterator.next() method must return an object');

--- a/src/lib/helpers/webidl.ts
+++ b/src/lib/helpers/webidl.ts
@@ -2,8 +2,11 @@ import { rethrowAssertionErrorRejection } from './miscellaneous';
 import assert from '../../stub/assert';
 
 const originalPromise = Promise;
+const originalPromiseResolve = Promise.resolve.bind(originalPromise);
 const originalPromiseThen = Promise.prototype.then;
 const originalPromiseReject = Promise.reject.bind(originalPromise);
+
+export const promiseResolve = originalPromiseResolve;
 
 // https://webidl.spec.whatwg.org/#a-new-promise
 export function newPromise<T>(executor: (

--- a/src/lib/readable-stream/from.ts
+++ b/src/lib/readable-stream/from.ts
@@ -5,7 +5,7 @@ import {
   type ReadableStreamLike
 } from './readable-stream-like';
 import { ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue } from './default-controller';
-import { GetIterator, GetMethod, IteratorComplete, IteratorNext, IteratorValue } from '../abstract-ops/ecmascript';
+import { GetIterator, GetMethod, IteratorNext } from '../abstract-ops/ecmascript';
 import { promiseCall, promiseRejectedWith, promiseResolvedWith, transformPromiseWith } from '../helpers/webidl';
 import { typeIsObject } from '../helpers/miscellaneous';
 import { noop } from '../../utils';
@@ -37,11 +37,11 @@ export function ReadableStreamFromIterable<R>(asyncIterable: Iterable<R> | Async
       if (!typeIsObject(iterResult)) {
         throw new TypeError('The promise returned by the iterator.next() method must fulfill with an object');
       }
-      const done = IteratorComplete(iterResult);
+      const done = iterResult.done;
       if (done) {
         ReadableStreamDefaultControllerClose(stream._readableStreamController);
       } else {
-        const value = IteratorValue(iterResult);
+        const value = iterResult.value;
         ReadableStreamDefaultControllerEnqueue(stream._readableStreamController, value);
       }
     });

--- a/src/lib/readable-stream/from.ts
+++ b/src/lib/readable-stream/from.ts
@@ -6,7 +6,7 @@ import {
 } from './readable-stream-like';
 import { ReadableStreamDefaultControllerClose, ReadableStreamDefaultControllerEnqueue } from './default-controller';
 import { GetIterator, GetMethod, IteratorComplete, IteratorNext, IteratorValue } from '../abstract-ops/ecmascript';
-import { promiseRejectedWith, promiseResolvedWith, reflectCall, transformPromiseWith } from '../helpers/webidl';
+import { promiseCall, promiseRejectedWith, promiseResolvedWith, transformPromiseWith } from '../helpers/webidl';
 import { typeIsObject } from '../helpers/miscellaneous';
 import { noop } from '../../utils';
 
@@ -58,13 +58,7 @@ export function ReadableStreamFromIterable<R>(asyncIterable: Iterable<R> | Async
     if (returnMethod === undefined) {
       return promiseResolvedWith(undefined);
     }
-    let returnResult: IteratorResult<R> | Promise<IteratorResult<R>>;
-    try {
-      returnResult = reflectCall(returnMethod, iterator, [reason]);
-    } catch (e) {
-      return promiseRejectedWith(e);
-    }
-    const returnPromise = promiseResolvedWith(returnResult);
+    const returnPromise = promiseCall(returnMethod, iterator, [reason]);
     return transformPromiseWith(returnPromise, iterResult => {
       if (!typeIsObject(iterResult)) {
         throw new TypeError('The promise returned by the iterator.return() method must fulfill with an object');


### PR DESCRIPTION
The [current implementation](https://github.com/MattiasBuelens/web-streams-polyfill/blob/0616eb64b9c6ff72439fed79f787fbbdc74efcb1/src/lib/abstract-ops/ecmascript.ts#L96-L111) of `CreateAsyncFromSyncIterator` uses an `async function*` to turn a sync iterator into an async iterator. This reduces the amount of code we have to *write*, but it does pull in a lot of extra helpers to down-level the async generator function (such as `__generator` and `__asyncGenerator` from [tslib](https://www.npmjs.com/package/tslib)).

This PR re-implements `CreateAsyncFromSyncIterator` manually, based on [the spec](https://tc39.es/ecma262/#sec-createasyncfromsynciterator). The code isn't that much longer, but the package size is smaller.