### PR TITLE
Optimize reading and piping from buffered stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@
 > - 🏠 Internal
 > - 💅 Polish
 
+## Unreleased
+
+* 🚀 Optimize reading from a `ReadableStream` with buffered chunks. ([#170](https://github.com/MattiasBuelens/web-streams-polyfill/pull/170))
+  * When the stream has a chunk available in its internal queue, `defaultReader.read()` and `byobReader.read(view)`
+    will now immediately return a resolved promise using `Promise.resolve()`.
+    This turns out to be (slightly) faster than creating a `new Promise` and then immediately resolving it.
+* 🚀 Optimize piping from a `ReadableStream` with buffered chunks. ([#170](https://github.com/MattiasBuelens/web-streams-polyfill/pull/170))
+  * When the stream has one or more chunks available in its internal queue, `pipeTo()` will now read all available chunks
+    in a single batch and write them to the destination (while still respecting backpressure).
+  * These optimizations were [inspired by Node.js](https://github.com/nodejs/node/commit/199daab0b0822d6063a73b9362bfce8667d2a112).
+
 ## 4.2.0 (2025-08-17)
 
 * 👓 Align with [spec version `080852c`](https://github.com/whatwg/streams/tree/080852ccd709e063cc6af239ae07fc040e365179/) ([#161](https://github.com/MattiasBuelens/web-streams-polyfill/pull/161))

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -53,6 +53,7 @@ function build({ target } = {}) {
         file: `dist/polyfill${target === 'es6' ? '' : `.${target}`}.js`,
         format: 'iife',
         exports: 'none',
+        sourcemap: debug ? 'inline' : false,
         banner,
         freeze: false
       }
@@ -65,6 +66,7 @@ function build({ target } = {}) {
         file: `dist/ponyfill${target === 'es6' ? '' : `.${target}`}.js`,
         format: 'umd',
         exports: 'named',
+        sourcemap: debug ? 'inline' : false,
         name: 'WebStreamsPolyfill',
         banner,
         freeze: false
@@ -72,6 +74,7 @@ function build({ target } = {}) {
       {
         file: `dist/ponyfill${target === 'es6' ? '' : `.${target}`}.mjs`,
         format: 'es',
+        sourcemap: debug ? 'inline' : false,
         banner
       }
     ],
@@ -86,6 +89,8 @@ function plugins({ target }) {
   return [
     typescript({
       tsconfig: `tsconfig${target === 'es6' ? '' : `-${target}`}.json`,
+      inlineSourceMap: debug,
+      inlineSources: debug,
       declaration: false,
       declarationMap: false
     }),

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -42,6 +42,9 @@ const keepNames = [
 ];
 const keepRegex = new RegExp(`^(${keepNames.join('|')})$`);
 
+/**
+ * @returns {import('rollup').RollupOptions[]}
+ */
 function build({ target } = {}) {
   return [{
     input: `src/polyfill.ts`,
@@ -76,6 +79,9 @@ function build({ target } = {}) {
   }];
 }
 
+/**
+ * @returns {import('rollup').Plugin[]}
+ */
 function plugins({ target }) {
   return [
     typescript({

--- a/src/lib/abstract-ops/internal-methods.ts
+++ b/src/lib/abstract-ops/internal-methods.ts
@@ -2,4 +2,5 @@ export const AbortSteps = Symbol('[[AbortSteps]]');
 export const ErrorSteps = Symbol('[[ErrorSteps]]');
 export const CancelSteps = Symbol('[[CancelSteps]]');
 export const PullSteps = Symbol('[[PullSteps]]');
+export const CanPullSyncSteps = Symbol('[[CanPullSyncSteps]]');
 export const ReleaseSteps = Symbol('[[ReleaseSteps]]');

--- a/src/lib/readable-stream/async-iterator.ts
+++ b/src/lib/readable-stream/async-iterator.ts
@@ -30,10 +30,10 @@ export interface ReadableStreamAsyncIterator<R> extends AsyncIterableIterator<R>
 }
 
 export class ReadableStreamAsyncIteratorImpl<R> {
-  private readonly _reader: ReadableStreamDefaultReader<R>;
-  private readonly _preventCancel: boolean;
-  private _ongoingPromise: Promise<ReadableStreamDefaultReadResult<R>> | undefined = undefined;
-  private _isFinished = false;
+  readonly _reader: ReadableStreamDefaultReader<R>;
+  readonly _preventCancel: boolean;
+  _ongoingPromise: Promise<ReadableStreamDefaultReadResult<R>> | undefined = undefined;
+  _isFinished = false;
 
   constructor(reader: ReadableStreamDefaultReader<R>, preventCancel: boolean) {
     this._reader = reader;
@@ -64,34 +64,9 @@ export class ReadableStreamAsyncIteratorImpl<R> {
     const reader = this._reader;
     assert(reader._ownerReadableStream !== undefined);
 
-    let resolvePromise!: (result: ReadableStreamDefaultReadResult<R>) => void;
-    let rejectPromise!: (reason: any) => void;
-    const promise = newPromise<ReadableStreamDefaultReadResult<R>>((resolve, reject) => {
-      resolvePromise = resolve;
-      rejectPromise = reject;
-    });
-    const readRequest: ReadRequest<R> = {
-      _chunkSteps: (chunk) => {
-        this._ongoingPromise = undefined;
-        // This needs to be delayed by one microtask, otherwise we stop pulling too early which breaks a test.
-        // FIXME Is this a bug in the specification, or in the test?
-        queueMicrotask(() => resolvePromise({ value: chunk, done: false }));
-      },
-      _closeSteps: () => {
-        this._ongoingPromise = undefined;
-        this._isFinished = true;
-        ReadableStreamReaderGenericRelease(reader);
-        resolvePromise({ value: undefined, done: true });
-      },
-      _errorSteps: (reason) => {
-        this._ongoingPromise = undefined;
-        this._isFinished = true;
-        ReadableStreamReaderGenericRelease(reader);
-        rejectPromise(reason);
-      }
-    };
+    const readRequest = new AsyncIteratorReadRequest<R>(this);
     ReadableStreamDefaultReaderRead(reader, readRequest);
-    return promise;
+    return readRequest._promise;
   }
 
   private _returnSteps(value: any): Promise<ReadableStreamDefaultReadResult<any>> {
@@ -112,6 +87,45 @@ export class ReadableStreamAsyncIteratorImpl<R> {
 
     ReadableStreamReaderGenericRelease(reader);
     return promiseResolvedWith({ value, done: true });
+  }
+}
+
+class AsyncIteratorReadRequest<R> implements ReadRequest<R> {
+  private readonly _iterator: ReadableStreamAsyncIteratorImpl<R>;
+  readonly _promise: Promise<ReadableStreamDefaultReadResult<R>>;
+  private _resolvePromise!: (result: ReadableStreamDefaultReadResult<R>) => void;
+  private _rejectPromise!: (reason: any) => void;
+
+  constructor(iterator: ReadableStreamAsyncIteratorImpl<R>) {
+    this._iterator = iterator;
+    this._promise = newPromise((resolve, reject) => {
+      this._resolvePromise = resolve;
+      this._rejectPromise = reject;
+    });
+  }
+
+  _chunkSteps(chunk: R) {
+    const iterator = this._iterator;
+    iterator._ongoingPromise = undefined;
+    // This needs to be delayed by one microtask, otherwise we stop pulling too early which breaks a test.
+    // FIXME Is this a bug in the specification, or in the test?
+    queueMicrotask(() => this._resolvePromise({ value: chunk, done: false }));
+  }
+
+  _closeSteps() {
+    const iterator = this._iterator;
+    iterator._ongoingPromise = undefined;
+    iterator._isFinished = true;
+    ReadableStreamReaderGenericRelease(iterator._reader);
+    this._resolvePromise({ value: undefined, done: true });
+  }
+
+  _errorSteps(reason: any) {
+    const iterator = this._iterator;
+    iterator._ongoingPromise = undefined;
+    iterator._isFinished = true;
+    ReadableStreamReaderGenericRelease(iterator._reader);
+    this._rejectPromise(reason);
   }
 }
 

--- a/src/lib/readable-stream/byob-reader.ts
+++ b/src/lib/readable-stream/byob-reader.ts
@@ -217,15 +217,11 @@ export class ReadableStreamBYOBReader {
 
     // Fast path: if the read can be resolved synchronously,
     // create a fulfilled/rejected promise directly.
-    if (ReadableStreamBYOBReaderCanReadSync(this, view, min)) {
-      const readIntoRequest = new SyncByobReadIntoRequest<T>();
-      ReadableStreamBYOBReaderRead(this, view, min, readIntoRequest);
-      assert(readIntoRequest._promise !== undefined);
-      return readIntoRequest._promise;
-    }
-
-    const readIntoRequest = new ByobReadIntoRequest<T>();
+    const readIntoRequest = ReadableStreamBYOBReaderCanReadSync(this, view, min)
+      ? new SyncByobReadIntoRequest<T>()
+      : new ByobReadIntoRequest<T>();
     ReadableStreamBYOBReaderRead(this, view, min, readIntoRequest);
+    assert(readIntoRequest._promise !== undefined);
     return readIntoRequest._promise;
   }
 

--- a/src/lib/readable-stream/byob-reader.ts
+++ b/src/lib/readable-stream/byob-reader.ts
@@ -218,30 +218,15 @@ export class ReadableStreamBYOBReader {
     // Fast path: if the read can be resolved synchronously,
     // create a fulfilled/rejected promise directly.
     if (ReadableStreamBYOBReaderCanReadSync(this, view, min)) {
-      let promise: Promise<ReadableStreamBYOBReadResult<T>> | undefined;
-      const readIntoRequest: ReadIntoRequest<T> = {
-        _chunkSteps: chunk => promise = promiseResolve({ value: chunk, done: false }),
-        _closeSteps: chunk => promise = promiseResolve({ value: chunk, done: true }),
-        _errorSteps: e => promise = promiseRejectedWith(e)
-      };
+      const readIntoRequest = new SyncByobReadIntoRequest<T>();
       ReadableStreamBYOBReaderRead(this, view, min, readIntoRequest);
-      assert(promise !== undefined);
-      return promise;
+      assert(readIntoRequest._promise !== undefined);
+      return readIntoRequest._promise;
     }
 
-    let resolvePromise!: (result: ReadableStreamBYOBReadResult<T>) => void;
-    let rejectPromise!: (reason: any) => void;
-    const promise = newPromise<ReadableStreamBYOBReadResult<T>>((resolve, reject) => {
-      resolvePromise = resolve;
-      rejectPromise = reject;
-    });
-    const readIntoRequest: ReadIntoRequest<T> = {
-      _chunkSteps: chunk => resolvePromise({ value: chunk, done: false }),
-      _closeSteps: chunk => resolvePromise({ value: chunk, done: true }),
-      _errorSteps: e => rejectPromise(e)
-    };
+    const readIntoRequest = new ByobReadIntoRequest<T>();
     ReadableStreamBYOBReaderRead(this, view, min, readIntoRequest);
-    return promise;
+    return readIntoRequest._promise;
   }
 
   /**
@@ -283,6 +268,50 @@ if (typeof Symbol.toStringTag === 'symbol') {
 }
 
 // Abstract operations for the readers.
+
+class ByobReadIntoRequest<T extends ArrayBufferView> implements ReadIntoRequest<T> {
+  readonly _promise: Promise<ReadableStreamBYOBReadResult<T>>;
+  private _resolvePromise!: (result: ReadableStreamBYOBReadResult<T>) => void;
+  private _rejectPromise!: (reason: any) => void;
+
+  constructor() {
+    this._promise = newPromise((resolve, reject) => {
+      this._resolvePromise = resolve;
+      this._rejectPromise = reject;
+    });
+  }
+
+  _chunkSteps(chunk: T) {
+    this._resolvePromise({ value: chunk, done: false });
+  }
+
+  _closeSteps(chunk: T | undefined) {
+    this._resolvePromise({ value: chunk, done: true });
+  }
+
+  _errorSteps(e: any) {
+    this._rejectPromise(e);
+  }
+}
+
+class SyncByobReadIntoRequest<T extends ArrayBufferView> implements ReadIntoRequest<T> {
+  _promise: Promise<ReadableStreamBYOBReadResult<T>> | undefined = undefined;
+
+  _chunkSteps(chunk: T) {
+    assert(this._promise === undefined);
+    this._promise = promiseResolve({ value: chunk, done: false });
+  }
+
+  _closeSteps(chunk: T | undefined) {
+    assert(this._promise === undefined);
+    this._promise = promiseResolve({ value: chunk, done: true });
+  }
+
+  _errorSteps(e: any) {
+    assert(this._promise === undefined);
+    this._promise = promiseRejectedWith(e);
+  }
+}
 
 export function IsReadableStreamBYOBReader(x: any): x is ReadableStreamBYOBReader {
   if (!typeIsObject(x)) {

--- a/src/lib/readable-stream/byob-reader.ts
+++ b/src/lib/readable-stream/byob-reader.ts
@@ -10,10 +10,11 @@ import { IsReadableStreamLocked, type ReadableByteStream, type ReadableStream } 
 import {
   IsReadableByteStreamController,
   ReadableByteStreamController,
+  ReadableByteStreamControllerCanPullIntoSync,
   ReadableByteStreamControllerPullInto
 } from './byte-stream-controller';
 import { setFunctionName, typeIsObject } from '../helpers/miscellaneous';
-import { newPromise, promiseRejectedWith } from '../helpers/webidl';
+import { newPromise, promiseRejectedWith, promiseResolve } from '../helpers/webidl';
 import { assertRequiredArgument } from '../validators/basic';
 import { assertReadableStream } from '../validators/readable-stream';
 import { IsDetachedBuffer } from '../abstract-ops/ecmascript';
@@ -214,6 +215,20 @@ export class ReadableStreamBYOBReader {
       return promiseRejectedWith(readerLockException('read from'));
     }
 
+    // Fast path: if the read can be resolved synchronously,
+    // create a fulfilled/rejected promise directly.
+    if (ReadableStreamBYOBReaderCanReadSync(this, view, min)) {
+      let promise: Promise<ReadableStreamBYOBReadResult<T>> | undefined;
+      const readIntoRequest: ReadIntoRequest<T> = {
+        _chunkSteps: chunk => promise = promiseResolve({ value: chunk, done: false }),
+        _closeSteps: chunk => promise = promiseResolve({ value: chunk, done: true }),
+        _errorSteps: e => promise = promiseRejectedWith(e)
+      };
+      ReadableStreamBYOBReaderRead(this, view, min, readIntoRequest);
+      assert(promise !== undefined);
+      return promise;
+    }
+
     let resolvePromise!: (result: ReadableStreamBYOBReadResult<T>) => void;
     let rejectPromise!: (reason: any) => void;
     const promise = newPromise<ReadableStreamBYOBReadResult<T>>((resolve, reject) => {
@@ -301,6 +316,30 @@ export function ReadableStreamBYOBReaderRead<T extends ArrayBufferView<ArrayBuff
       view,
       min,
       readIntoRequest
+    );
+  }
+}
+
+/**
+ * Returns whether {@link ReadableStreamBYOBReaderRead}
+ * can synchronously read a chunk from the queue.
+ */
+export function ReadableStreamBYOBReaderCanReadSync<T extends ArrayBufferView<ArrayBuffer>>(
+  reader: ReadableStreamBYOBReader,
+  view: T,
+  min: number
+): boolean {
+  const stream = reader._ownerReadableStream;
+
+  assert(stream !== undefined);
+
+  if (stream._state === 'errored') {
+    return true;
+  } else {
+    return ReadableByteStreamControllerCanPullIntoSync(
+      stream._readableStreamController as ReadableByteStreamController,
+      view,
+      min
     );
   }
 }

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -738,6 +738,37 @@ export function ReadableByteStreamControllerPullInto<T extends ArrayBufferView<A
   ReadableByteStreamControllerCallPullIfNeeded(controller);
 }
 
+/**
+ * Returns whether {@link ReadableByteStreamControllerPullInto}
+ * can synchronously fill a new read-into request.
+ */
+export function ReadableByteStreamControllerCanPullIntoSync<T extends ArrayBufferView<ArrayBuffer>>(
+  controller: ReadableByteStreamController,
+  view: T,
+  min: number
+): boolean {
+  const stream = controller._controlledReadableByteStream;
+
+  const ctor = view.constructor as ArrayBufferViewConstructor<T>;
+  const elementSize = arrayBufferViewElementSize(ctor);
+
+  const { byteLength } = view;
+
+  const minimumFill = min * elementSize;
+  assert(minimumFill >= elementSize && minimumFill <= byteLength);
+  assert(minimumFill % elementSize === 0);
+
+  if (controller._pendingPullIntos.length > 0) {
+    return false;
+  }
+
+  if (stream._state === 'closed') {
+    return true;
+  }
+
+  return controller._queueTotalSize >= minimumFill;
+}
+
 function ReadableByteStreamControllerRespondInClosedState(
   controller: ReadableByteStreamController,
   firstDescriptor: PullIntoDescriptor

--- a/src/lib/readable-stream/byte-stream-controller.ts
+++ b/src/lib/readable-stream/byte-stream-controller.ts
@@ -33,7 +33,7 @@ import {
   IsDetachedBuffer,
   TransferArrayBuffer
 } from '../abstract-ops/ecmascript';
-import { CancelSteps, PullSteps, ReleaseSteps } from '../abstract-ops/internal-methods';
+import { CancelSteps, CanPullSyncSteps, PullSteps, ReleaseSteps } from '../abstract-ops/internal-methods';
 import { promiseResolvedWith, uponPromise } from '../helpers/webidl';
 import { assertRequiredArgument, convertUnsignedLongLongWithEnforceRange } from '../validators/basic';
 import {
@@ -350,6 +350,11 @@ export class ReadableByteStreamController {
 
     ReadableStreamAddReadRequest(stream, readRequest);
     ReadableByteStreamControllerCallPullIfNeeded(this);
+  }
+
+  /** @internal */
+  [CanPullSyncSteps](): boolean {
+    return this._queueTotalSize > 0;
   }
 
   /** @internal */

--- a/src/lib/readable-stream/default-controller.ts
+++ b/src/lib/readable-stream/default-controller.ts
@@ -11,7 +11,7 @@ import { SimpleQueue } from '../simple-queue';
 import { IsReadableStreamLocked, ReadableStream, ReadableStreamClose, ReadableStreamError } from '../readable-stream';
 import type { ValidatedUnderlyingSource } from './underlying-source';
 import { setFunctionName, typeIsObject } from '../helpers/miscellaneous';
-import { CancelSteps, PullSteps, ReleaseSteps } from '../abstract-ops/internal-methods';
+import { CancelSteps, CanPullSyncSteps, PullSteps, ReleaseSteps } from '../abstract-ops/internal-methods';
 import { promiseResolvedWith, uponPromise } from '../helpers/webidl';
 
 /**
@@ -129,6 +129,11 @@ export class ReadableStreamDefaultController<R> {
       ReadableStreamAddReadRequest(stream, readRequest);
       ReadableStreamDefaultControllerCallPullIfNeeded(this);
     }
+  }
+
+  /** @internal */
+  [CanPullSyncSteps](): boolean {
+    return this._queue.length > 0;
   }
 
   /** @internal */

--- a/src/lib/readable-stream/default-reader.ts
+++ b/src/lib/readable-stream/default-reader.ts
@@ -9,7 +9,7 @@ import {
 import { IsReadableStreamLocked, ReadableStream } from '../readable-stream';
 import { setFunctionName, typeIsObject } from '../helpers/miscellaneous';
 import { CanPullSyncSteps, PullSteps } from '../abstract-ops/internal-methods';
-import { newPromise, promiseRejectedWith, promiseResolvedWith } from '../helpers/webidl';
+import { newPromise, promiseRejectedWith, promiseResolve } from '../helpers/webidl';
 import { assertRequiredArgument } from '../validators/basic';
 import { assertReadableStream } from '../validators/readable-stream';
 
@@ -161,8 +161,8 @@ export class ReadableStreamDefaultReader<R = any> {
     if (ReadableStreamDefaultReaderCanReadSync(this)) {
       let promise: Promise<ReadableStreamDefaultReadResult<R>> | undefined;
       const readRequest: ReadRequest<R> = {
-        _chunkSteps: chunk => promise = promiseResolvedWith({ value: chunk, done: false }),
-        _closeSteps: () => promise = promiseResolvedWith({ value: undefined, done: true }),
+        _chunkSteps: chunk => promise = promiseResolve({ value: chunk, done: false }),
+        _closeSteps: () => promise = promiseResolve({ value: undefined, done: true }),
         _errorSteps: e => promise = promiseRejectedWith(e)
       };
       ReadableStreamDefaultReaderRead(this, readRequest);

--- a/src/lib/readable-stream/default-reader.ts
+++ b/src/lib/readable-stream/default-reader.ts
@@ -8,8 +8,8 @@ import {
 } from './generic-reader';
 import { IsReadableStreamLocked, ReadableStream } from '../readable-stream';
 import { setFunctionName, typeIsObject } from '../helpers/miscellaneous';
-import { PullSteps } from '../abstract-ops/internal-methods';
-import { newPromise, promiseRejectedWith } from '../helpers/webidl';
+import { CanPullSyncSteps, PullSteps } from '../abstract-ops/internal-methods';
+import { newPromise, promiseRejectedWith, promiseResolvedWith } from '../helpers/webidl';
 import { assertRequiredArgument } from '../validators/basic';
 import { assertReadableStream } from '../validators/readable-stream';
 
@@ -156,6 +156,20 @@ export class ReadableStreamDefaultReader<R = any> {
       return promiseRejectedWith(readerLockException('read from'));
     }
 
+    // Fast path: if the read can be resolved synchronously,
+    // create a fulfilled/rejected promise directly.
+    if (ReadableStreamDefaultReaderCanReadSync(this)) {
+      let promise: Promise<ReadableStreamDefaultReadResult<R>> | undefined;
+      const readRequest: ReadRequest<R> = {
+        _chunkSteps: chunk => promise = promiseResolvedWith({ value: chunk, done: false }),
+        _closeSteps: () => promise = promiseResolvedWith({ value: undefined, done: true }),
+        _errorSteps: e => promise = promiseRejectedWith(e)
+      };
+      ReadableStreamDefaultReaderRead(this, readRequest);
+      assert(promise !== undefined);
+      return promise;
+    }
+
     let resolvePromise!: (result: ReadableStreamDefaultReadResult<R>) => void;
     let rejectPromise!: (reason: any) => void;
     const promise = newPromise<ReadableStreamDefaultReadResult<R>>((resolve, reject) => {
@@ -240,6 +254,25 @@ export function ReadableStreamDefaultReaderRead<R>(
   } else {
     assert(stream._state === 'readable');
     stream._readableStreamController[PullSteps](readRequest as ReadRequest<any>);
+  }
+}
+
+/**
+ * Returns whether {@link ReadableStreamDefaultReaderRead}
+ * can synchronously read a chunk from the queue.
+ */
+export function ReadableStreamDefaultReaderCanReadSync<R>(reader: ReadableStreamDefaultReader<R>): boolean {
+  const stream = reader._ownerReadableStream;
+
+  assert(stream !== undefined);
+
+  if (stream._state === 'closed') {
+    return true;
+  } else if (stream._state === 'errored') {
+    return true;
+  } else {
+    assert(stream._state === 'readable');
+    return stream._readableStreamController[CanPullSyncSteps]();
   }
 }
 

--- a/src/lib/readable-stream/default-reader.ts
+++ b/src/lib/readable-stream/default-reader.ts
@@ -158,15 +158,11 @@ export class ReadableStreamDefaultReader<R = any> {
 
     // Fast path: if the read can be resolved synchronously,
     // create a fulfilled/rejected promise directly.
-    if (ReadableStreamDefaultReaderCanReadSync(this)) {
-      const readRequest = new SyncDefaultReadRequest<R>();
-      ReadableStreamDefaultReaderRead(this, readRequest);
-      assert(readRequest._promise !== undefined);
-      return readRequest._promise;
-    }
-
-    const readRequest = new DefaultReadRequest<R>();
+    const readRequest = ReadableStreamDefaultReaderCanReadSync(this)
+      ? new SyncDefaultReadRequest<R>()
+      : new DefaultReadRequest<R>();
     ReadableStreamDefaultReaderRead(this, readRequest);
+    assert(readRequest._promise !== undefined);
     return readRequest._promise;
   }
 

--- a/src/lib/readable-stream/default-reader.ts
+++ b/src/lib/readable-stream/default-reader.ts
@@ -159,30 +159,15 @@ export class ReadableStreamDefaultReader<R = any> {
     // Fast path: if the read can be resolved synchronously,
     // create a fulfilled/rejected promise directly.
     if (ReadableStreamDefaultReaderCanReadSync(this)) {
-      let promise: Promise<ReadableStreamDefaultReadResult<R>> | undefined;
-      const readRequest: ReadRequest<R> = {
-        _chunkSteps: chunk => promise = promiseResolve({ value: chunk, done: false }),
-        _closeSteps: () => promise = promiseResolve({ value: undefined, done: true }),
-        _errorSteps: e => promise = promiseRejectedWith(e)
-      };
+      const readRequest = new SyncDefaultReadRequest<R>();
       ReadableStreamDefaultReaderRead(this, readRequest);
-      assert(promise !== undefined);
-      return promise;
+      assert(readRequest._promise !== undefined);
+      return readRequest._promise;
     }
 
-    let resolvePromise!: (result: ReadableStreamDefaultReadResult<R>) => void;
-    let rejectPromise!: (reason: any) => void;
-    const promise = newPromise<ReadableStreamDefaultReadResult<R>>((resolve, reject) => {
-      resolvePromise = resolve;
-      rejectPromise = reject;
-    });
-    const readRequest: ReadRequest<R> = {
-      _chunkSteps: chunk => resolvePromise({ value: chunk, done: false }),
-      _closeSteps: () => resolvePromise({ value: undefined, done: true }),
-      _errorSteps: e => rejectPromise(e)
-    };
+    const readRequest = new DefaultReadRequest<R>();
     ReadableStreamDefaultReaderRead(this, readRequest);
-    return promise;
+    return readRequest._promise;
   }
 
   /**
@@ -224,6 +209,50 @@ if (typeof Symbol.toStringTag === 'symbol') {
 }
 
 // Abstract operations for the readers.
+
+class DefaultReadRequest<R> implements ReadRequest<R> {
+  readonly _promise: Promise<ReadableStreamDefaultReadResult<R>>;
+  private _resolvePromise!: (result: ReadableStreamDefaultReadResult<R>) => void;
+  private _rejectPromise!: (reason: any) => void;
+
+  constructor() {
+    this._promise = newPromise((resolve, reject) => {
+      this._resolvePromise = resolve;
+      this._rejectPromise = reject;
+    });
+  }
+
+  _chunkSteps(chunk: R) {
+    this._resolvePromise({ value: chunk, done: false });
+  }
+
+  _closeSteps() {
+    this._resolvePromise({ value: undefined, done: true });
+  }
+
+  _errorSteps(e: any) {
+    this._rejectPromise(e);
+  }
+}
+
+class SyncDefaultReadRequest<R> implements ReadRequest<R> {
+  _promise: Promise<ReadableStreamDefaultReadResult<R>> | undefined = undefined;
+
+  _chunkSteps(chunk: R) {
+    assert(this._promise === undefined);
+    this._promise = promiseResolve({ value: chunk, done: false });
+  }
+
+  _closeSteps() {
+    assert(this._promise === undefined);
+    this._promise = promiseResolve({ value: undefined, done: true });
+  }
+
+  _errorSteps(e: any) {
+    assert(this._promise === undefined);
+    this._promise = promiseRejectedWith(e);
+  }
+}
 
 export function IsReadableStreamDefaultReader<R = any>(x: any): x is ReadableStreamDefaultReader<R> {
   if (!typeIsObject(x)) {

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -2,7 +2,7 @@ import { IsReadableStream, IsReadableStreamLocked, ReadableStream, ReadableStrea
 import {
   AcquireReadableStreamDefaultReader,
   ReadableStreamDefaultReaderCanReadSync,
-  ReadableStreamDefaultReaderRead
+  ReadableStreamDefaultReaderRead, type ReadRequest
 } from './default-reader';
 import { ReadableStreamReaderGenericRelease } from './generic-reader';
 import {
@@ -109,6 +109,14 @@ export function ReadableStreamPipeTo<T>(
       });
     }
 
+    const syncPipeToReadRequest: ReadRequest<T> = {
+      _chunkSteps: (chunk) => {
+        currentWrite = PerformPromiseThen(WritableStreamDefaultWriterWrite(writer, chunk), undefined, noop);
+      },
+      _closeSteps: unexpected,
+      _errorSteps: unexpected
+    };
+
     function pipeStep(): Promise<boolean> {
       // Fast path: read available chunks synchronously in a single batch
       while (
@@ -119,16 +127,7 @@ export function ReadableStreamPipeTo<T>(
         && source._state === 'readable'
         && ReadableStreamDefaultReaderCanReadSync(reader)
       ) {
-        ReadableStreamDefaultReaderRead(
-          reader,
-          {
-            _chunkSteps: (chunk) => {
-              currentWrite = PerformPromiseThen(WritableStreamDefaultWriterWrite(writer, chunk), undefined, noop);
-            },
-            _closeSteps: unexpected,
-            _errorSteps: unexpected
-          }
-        );
+        ReadableStreamDefaultReaderRead(reader, syncPipeToReadRequest);
       }
 
       // Slow path: wait for chunk to become available

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -2,7 +2,8 @@ import { IsReadableStream, IsReadableStreamLocked, ReadableStream, ReadableStrea
 import {
   AcquireReadableStreamDefaultReader,
   ReadableStreamDefaultReaderCanReadSync,
-  ReadableStreamDefaultReaderRead, type ReadRequest
+  ReadableStreamDefaultReaderRead,
+  type ReadRequest
 } from './default-reader';
 import { ReadableStreamReaderGenericRelease } from './generic-reader';
 import {

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -1,5 +1,9 @@
 import { IsReadableStream, IsReadableStreamLocked, ReadableStream, ReadableStreamCancel } from '../readable-stream';
-import { AcquireReadableStreamDefaultReader, ReadableStreamDefaultReaderRead } from './default-reader';
+import {
+  AcquireReadableStreamDefaultReader,
+  ReadableStreamDefaultReaderCanReadSync,
+  ReadableStreamDefaultReaderRead
+} from './default-reader';
 import { ReadableStreamReaderGenericRelease } from './generic-reader';
 import {
   AcquireWritableStreamDefaultWriter,
@@ -12,7 +16,7 @@ import {
   WritableStreamDefaultWriterRelease,
   WritableStreamDefaultWriterWrite
 } from '../writable-stream';
-import assert from '../../stub/assert';
+import assert, { unexpected } from '../../stub/assert';
 import {
   newPromise,
   PerformPromiseThen,
@@ -106,6 +110,28 @@ export function ReadableStreamPipeTo<T>(
     }
 
     function pipeStep(): Promise<boolean> {
+      // Fast path: read available chunks synchronously in a single batch
+      while (
+        !shuttingDown
+        && !dest._backpressure
+        && dest._state === 'writable'
+        && !WritableStreamCloseQueuedOrInFlight(dest)
+        && source._state === 'readable'
+        && ReadableStreamDefaultReaderCanReadSync(reader)
+      ) {
+        ReadableStreamDefaultReaderRead(
+          reader,
+          {
+            _chunkSteps: (chunk) => {
+              currentWrite = PerformPromiseThen(WritableStreamDefaultWriterWrite(writer, chunk), undefined, noop);
+            },
+            _closeSteps: unexpected,
+            _errorSteps: unexpected
+          }
+        );
+      }
+
+      // Slow path: wait for chunk to become available
       if (shuttingDown) {
         return promiseResolvedWith(true);
       }

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -109,21 +109,21 @@ export function ReadableStreamPipeTo<T>(
       if (shuttingDown) {
         return promiseResolvedWith(true);
       }
-
-      return PerformPromiseThen(writer._readyPromise, () => {
-        return newPromise<boolean>((resolveRead, rejectRead) => {
-          ReadableStreamDefaultReaderRead(
-            reader,
-            {
-              _chunkSteps: (chunk) => {
-                currentWrite = PerformPromiseThen(WritableStreamDefaultWriterWrite(writer, chunk), undefined, noop);
-                resolveRead(false);
-              },
-              _closeSteps: () => resolveRead(true),
-              _errorSteps: rejectRead
-            }
-          );
-        });
+      if (dest._backpressure) {
+        return PerformPromiseThen(writer._readyPromise, pipeStep);
+      }
+      return newPromise<boolean>((resolveRead, rejectRead) => {
+        ReadableStreamDefaultReaderRead(
+          reader,
+          {
+            _chunkSteps: (chunk) => {
+              currentWrite = PerformPromiseThen(WritableStreamDefaultWriterWrite(writer, chunk), undefined, noop);
+              resolveRead(false);
+            },
+            _closeSteps: () => resolveRead(true),
+            _errorSteps: rejectRead
+          }
+        );
       });
     }
 

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -13,6 +13,7 @@ import {
   WritableStream,
   WritableStreamAbort,
   WritableStreamCloseQueuedOrInFlight,
+  WritableStreamDefaultWriter,
   WritableStreamDefaultWriterCloseWithErrorPropagation,
   WritableStreamDefaultWriterRelease,
   WritableStreamDefaultWriterWrite
@@ -53,10 +54,8 @@ export function ReadableStreamPipeTo<T>(
 
   source._disturbed = true;
 
-  let shuttingDown = false;
-
-  // This is used to keep track of the spec's requirement that we wait for ongoing writes during shutdown.
-  let currentWrite = promiseResolvedWith<void>(undefined);
+  const state = new PipeState<T>(writer);
+  const syncReadRequest = new SyncPipeReadRequest<T>(state);
 
   return newPromise((resolve, reject) => {
     let abortAlgorithm: () => void;
@@ -110,47 +109,29 @@ export function ReadableStreamPipeTo<T>(
       });
     }
 
-    const syncPipeToReadRequest: ReadRequest<T> = {
-      _chunkSteps: (chunk) => {
-        currentWrite = PerformPromiseThen(WritableStreamDefaultWriterWrite(writer, chunk), undefined, noop);
-      },
-      _closeSteps: unexpected,
-      _errorSteps: unexpected
-    };
-
     function pipeStep(): Promise<boolean> {
       // Fast path: read available chunks synchronously in a single batch
       while (
-        !shuttingDown
+        !state.shuttingDown
         && !dest._backpressure
         && dest._state === 'writable'
         && !WritableStreamCloseQueuedOrInFlight(dest)
         && source._state === 'readable'
         && ReadableStreamDefaultReaderCanReadSync(reader)
       ) {
-        ReadableStreamDefaultReaderRead(reader, syncPipeToReadRequest);
+        ReadableStreamDefaultReaderRead(reader, syncReadRequest);
       }
 
       // Slow path: wait for chunk to become available
-      if (shuttingDown) {
+      if (state.shuttingDown) {
         return promiseResolvedWith(true);
       }
       if (dest._backpressure) {
         return PerformPromiseThen(writer._readyPromise, pipeStep);
       }
-      return newPromise<boolean>((resolveRead, rejectRead) => {
-        ReadableStreamDefaultReaderRead(
-          reader,
-          {
-            _chunkSteps: (chunk) => {
-              currentWrite = PerformPromiseThen(WritableStreamDefaultWriterWrite(writer, chunk), undefined, noop);
-              resolveRead(false);
-            },
-            _closeSteps: () => resolveRead(true),
-            _errorSteps: rejectRead
-          }
-        );
-      });
+      const request = new PipeReadRequest(state);
+      ReadableStreamDefaultReaderRead(reader, request);
+      return request._promise;
     }
 
     // Errors must be propagated forward
@@ -199,10 +180,10 @@ export function ReadableStreamPipeTo<T>(
     function waitForWritesToFinish(): Promise<void> {
       // Another write may have started while we were waiting on this currentWrite, so we have to be sure to wait
       // for that too.
-      const oldCurrentWrite = currentWrite;
+      const oldCurrentWrite = state.currentWrite;
       return PerformPromiseThen(
-        currentWrite,
-        () => oldCurrentWrite !== currentWrite ? waitForWritesToFinish() : undefined
+        state.currentWrite,
+        () => oldCurrentWrite !== state.currentWrite ? waitForWritesToFinish() : undefined
       );
     }
 
@@ -227,10 +208,10 @@ export function ReadableStreamPipeTo<T>(
     }
 
     function shutdownWithAction(action: () => Promise<unknown>, originalIsError?: boolean, originalError?: any) {
-      if (shuttingDown) {
+      if (state.shuttingDown) {
         return;
       }
-      shuttingDown = true;
+      state.shuttingDown = true;
 
       if (dest._state === 'writable' && !WritableStreamCloseQueuedOrInFlight(dest)) {
         uponFulfillment(waitForWritesToFinish(), doTheRest);
@@ -249,10 +230,10 @@ export function ReadableStreamPipeTo<T>(
     }
 
     function shutdown(isError?: boolean, error?: any) {
-      if (shuttingDown) {
+      if (state.shuttingDown) {
         return;
       }
-      shuttingDown = true;
+      state.shuttingDown = true;
 
       if (dest._state === 'writable' && !WritableStreamCloseQueuedOrInFlight(dest)) {
         uponFulfillment(waitForWritesToFinish(), () => finalize(isError, error));
@@ -277,4 +258,67 @@ export function ReadableStreamPipeTo<T>(
       return null;
     }
   });
+}
+
+class PipeState<T> {
+  shuttingDown = false;
+
+  // This is used to keep track of the spec's requirement that we wait for ongoing writes during shutdown.
+  currentWrite = promiseResolvedWith<void>(undefined);
+
+  constructor(readonly writer: WritableStreamDefaultWriter<T>) {}
+}
+
+class PipeReadRequest<T> implements ReadRequest<T> {
+  readonly _state: PipeState<T>;
+
+  readonly _promise: Promise<boolean>;
+  private _resolvePromise!: (done: boolean) => void;
+  private _rejectPromise!: (reason: any) => void;
+
+  constructor(state: PipeState<T>) {
+    this._state = state;
+    this._promise = newPromise((resolve, reject) => {
+      this._resolvePromise = resolve;
+      this._rejectPromise = reject;
+    });
+  }
+
+  _chunkSteps(chunk: T) {
+    this._state.currentWrite = PerformPromiseThen(
+      WritableStreamDefaultWriterWrite(this._state.writer, chunk),
+      undefined,
+      noop
+    );
+    this._resolvePromise(false);
+  }
+
+  _closeSteps() {
+    this._resolvePromise(true);
+  }
+
+  _errorSteps(e: any) {
+    this._rejectPromise(e);
+  }
+}
+
+class SyncPipeReadRequest<T> implements ReadRequest<T> {
+  constructor(private _state: PipeState<T>) { }
+
+  _chunkSteps(chunk: T) {
+    this._state.currentWrite = PerformPromiseThen(
+      WritableStreamDefaultWriterWrite(this._state.writer, chunk),
+      undefined,
+      noop
+    );
+  }
+
+  _closeSteps() {
+    unexpected();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _errorSteps(_error: any) {
+    unexpected();
+  }
 }

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -112,7 +112,7 @@ export function ReadableStreamPipeTo<T>(
     function pipeStep(): Promise<boolean> {
       // Fast path: read available chunks synchronously in a single batch
       while (
-        !state.shuttingDown
+        !state._shuttingDown
         && !dest._backpressure
         && dest._state === 'writable'
         && !WritableStreamCloseQueuedOrInFlight(dest)
@@ -123,7 +123,7 @@ export function ReadableStreamPipeTo<T>(
       }
 
       // Slow path: wait for chunk to become available
-      if (state.shuttingDown) {
+      if (state._shuttingDown) {
         return promiseResolvedWith(true);
       }
       if (dest._backpressure) {
@@ -178,13 +178,13 @@ export function ReadableStreamPipeTo<T>(
     setPromiseIsHandledToTrue(pipeLoop());
 
     function shutdownWithAction(action: () => Promise<unknown>, originalIsError?: boolean, originalError?: any) {
-      if (state.shuttingDown) {
+      if (state._shuttingDown) {
         return;
       }
-      state.shuttingDown = true;
+      state._shuttingDown = true;
 
       if (dest._state === 'writable' && !WritableStreamCloseQueuedOrInFlight(dest)) {
-        uponFulfillment(state.waitForWritesToFinish(), doTheRest);
+        uponFulfillment(state._waitForWritesToFinish(), doTheRest);
       } else {
         doTheRest();
       }
@@ -200,13 +200,13 @@ export function ReadableStreamPipeTo<T>(
     }
 
     function shutdown(isError?: boolean, error?: any) {
-      if (state.shuttingDown) {
+      if (state._shuttingDown) {
         return;
       }
-      state.shuttingDown = true;
+      state._shuttingDown = true;
 
       if (dest._state === 'writable' && !WritableStreamCloseQueuedOrInFlight(dest)) {
-        uponFulfillment(state.waitForWritesToFinish(), () => finalize(isError, error));
+        uponFulfillment(state._waitForWritesToFinish(), () => finalize(isError, error));
       } else {
         finalize(isError, error);
       }
@@ -231,20 +231,20 @@ export function ReadableStreamPipeTo<T>(
 }
 
 class PipeState<T> {
-  shuttingDown = false;
+  _shuttingDown = false;
 
   // This is used to keep track of the spec's requirement that we wait for ongoing writes during shutdown.
-  currentWrite = promiseResolvedWith<void>(undefined);
+  _currentWrite = promiseResolvedWith<void>(undefined);
 
-  constructor(readonly writer: WritableStreamDefaultWriter<T>) {}
+  constructor(readonly _writer: WritableStreamDefaultWriter<T>) {}
 
-  waitForWritesToFinish(): Promise<void> {
+  _waitForWritesToFinish(): Promise<void> {
     // Another write may have started while we were waiting on this currentWrite, so we have to be sure to wait
     // for that too.
-    const oldCurrentWrite = this.currentWrite;
+    const oldCurrentWrite = this._currentWrite;
     return PerformPromiseThen(
-      this.currentWrite,
-      () => oldCurrentWrite !== this.currentWrite ? this.waitForWritesToFinish() : undefined
+      this._currentWrite,
+      () => oldCurrentWrite !== this._currentWrite ? this._waitForWritesToFinish() : undefined
     );
   }
 }
@@ -265,8 +265,8 @@ class PipeReadRequest<T> implements ReadRequest<T> {
   }
 
   _chunkSteps(chunk: T) {
-    this._state.currentWrite = PerformPromiseThen(
-      WritableStreamDefaultWriterWrite(this._state.writer, chunk),
+    this._state._currentWrite = PerformPromiseThen(
+      WritableStreamDefaultWriterWrite(this._state._writer, chunk),
       undefined,
       noop
     );
@@ -286,8 +286,8 @@ class SyncPipeReadRequest<T> implements ReadRequest<T> {
   constructor(private _state: PipeState<T>) { }
 
   _chunkSteps(chunk: T) {
-    this._state.currentWrite = PerformPromiseThen(
-      WritableStreamDefaultWriterWrite(this._state.writer, chunk),
+    this._state._currentWrite = PerformPromiseThen(
+      WritableStreamDefaultWriterWrite(this._state._writer, chunk),
       undefined,
       noop
     );

--- a/src/lib/readable-stream/pipe.ts
+++ b/src/lib/readable-stream/pipe.ts
@@ -177,36 +177,6 @@ export function ReadableStreamPipeTo<T>(
 
     setPromiseIsHandledToTrue(pipeLoop());
 
-    function waitForWritesToFinish(): Promise<void> {
-      // Another write may have started while we were waiting on this currentWrite, so we have to be sure to wait
-      // for that too.
-      const oldCurrentWrite = state.currentWrite;
-      return PerformPromiseThen(
-        state.currentWrite,
-        () => oldCurrentWrite !== state.currentWrite ? waitForWritesToFinish() : undefined
-      );
-    }
-
-    function isOrBecomesErrored(
-      stream: ReadableStream | WritableStream,
-      promise: Promise<void>,
-      action: (reason: any) => null
-    ) {
-      if (stream._state === 'errored') {
-        action(stream._storedError);
-      } else {
-        uponRejection(promise, action);
-      }
-    }
-
-    function isOrBecomesClosed(stream: ReadableStream | WritableStream, promise: Promise<void>, action: () => null) {
-      if (stream._state === 'closed') {
-        action();
-      } else {
-        uponFulfillment(promise, action);
-      }
-    }
-
     function shutdownWithAction(action: () => Promise<unknown>, originalIsError?: boolean, originalError?: any) {
       if (state.shuttingDown) {
         return;
@@ -214,7 +184,7 @@ export function ReadableStreamPipeTo<T>(
       state.shuttingDown = true;
 
       if (dest._state === 'writable' && !WritableStreamCloseQueuedOrInFlight(dest)) {
-        uponFulfillment(waitForWritesToFinish(), doTheRest);
+        uponFulfillment(state.waitForWritesToFinish(), doTheRest);
       } else {
         doTheRest();
       }
@@ -236,7 +206,7 @@ export function ReadableStreamPipeTo<T>(
       state.shuttingDown = true;
 
       if (dest._state === 'writable' && !WritableStreamCloseQueuedOrInFlight(dest)) {
-        uponFulfillment(waitForWritesToFinish(), () => finalize(isError, error));
+        uponFulfillment(state.waitForWritesToFinish(), () => finalize(isError, error));
       } else {
         finalize(isError, error);
       }
@@ -267,6 +237,16 @@ class PipeState<T> {
   currentWrite = promiseResolvedWith<void>(undefined);
 
   constructor(readonly writer: WritableStreamDefaultWriter<T>) {}
+
+  waitForWritesToFinish(): Promise<void> {
+    // Another write may have started while we were waiting on this currentWrite, so we have to be sure to wait
+    // for that too.
+    const oldCurrentWrite = this.currentWrite;
+    return PerformPromiseThen(
+      this.currentWrite,
+      () => oldCurrentWrite !== this.currentWrite ? this.waitForWritesToFinish() : undefined
+    );
+  }
 }
 
 class PipeReadRequest<T> implements ReadRequest<T> {
@@ -320,5 +300,25 @@ class SyncPipeReadRequest<T> implements ReadRequest<T> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _errorSteps(_error: any) {
     unexpected();
+  }
+}
+
+function isOrBecomesErrored(
+  stream: ReadableStream | WritableStream,
+  promise: Promise<void>,
+  action: (reason: any) => null
+) {
+  if (stream._state === 'errored') {
+    action(stream._storedError);
+  } else {
+    uponRejection(promise, action);
+  }
+}
+
+function isOrBecomesClosed(stream: ReadableStream | WritableStream, promise: Promise<void>, action: () => null) {
+  if (stream._state === 'closed') {
+    action();
+  } else {
+    uponFulfillment(promise, action);
   }
 }

--- a/src/stub/assert.ts
+++ b/src/stub/assert.ts
@@ -14,3 +14,5 @@ function assertImpl(test: boolean, message?: string): asserts test {
 
 const assert: typeof assertImpl = DEBUG ? assertImpl : noop;
 export default assert;
+
+export const unexpected = DEBUG ? () => assertImpl(false, 'cannot happen') : noop;

--- a/test/unit/readable-stream/default-reader.spec.js
+++ b/test/unit/readable-stream/default-reader.spec.js
@@ -1,0 +1,56 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { ReadableStream } = require('web-streams-polyfill');
+
+describe('ReadableStreamDefaultReader', () => {
+  // https://github.com/nodejs/node/commit/199daab0b0822d6063a73b9362bfce8667d2a112
+  describe('read() with prefilled buffer', () => {
+    const n = 1e5;
+
+    async function test(bufferSize) {
+      let enqueued = 0;
+
+      const rs = new ReadableStream({
+        start(controller) {
+          // Pre-fill the buffer
+          for (let i = 0; i < bufferSize; i++) {
+            controller.enqueue('a');
+            enqueued++;
+          }
+        },
+        pull(controller) {
+          // Refill buffer when pulled
+          const toEnqueue = Math.min(bufferSize, n - enqueued);
+          for (let i = 0; i < toEnqueue; i++) {
+            controller.enqueue('a');
+            enqueued++;
+          }
+          if (enqueued >= n) {
+            controller.close();
+          }
+        }
+      }, {
+        // Use buffer size as high water mark to allow pre-buffering
+        highWaterMark: bufferSize
+      });
+
+      const reader = rs.getReader();
+      let x;
+      let reads = 0;
+
+      while (reads < n) {
+        const { value, done } = await reader.read();
+        if (done) {
+          break;
+        }
+        x = value;
+        reads++;
+      }
+      assert.equal(x, 'a');
+    }
+
+    for (const bufferSize of [1, 10, 100, 1000]) {
+      it(`of size ${bufferSize}`, () => test(bufferSize));
+    }
+  });
+});

--- a/test/unit/readable-stream/pipe.spec.js
+++ b/test/unit/readable-stream/pipe.spec.js
@@ -1,0 +1,52 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { ReadableStream, WritableStream } = require('web-streams-polyfill');
+
+describe('ReadableStream.pipeTo', () => {
+  // https://github.com/nodejs/node/commit/199daab0b0822d6063a73b9362bfce8667d2a112
+  describe('with prefilled buffer', () => {
+    const n = 1e5;
+
+    async function test(bufferSize) {
+      let enqueued = 0;
+
+      const rs = new ReadableStream({
+        start(controller) {
+          // Pre-fill the buffer
+          for (let i = 0; i < bufferSize; i++) {
+            controller.enqueue('a');
+            enqueued++;
+          }
+        },
+        pull(controller) {
+          // Refill buffer when pulled
+          const toEnqueue = Math.min(bufferSize, n - enqueued);
+          for (let i = 0; i < toEnqueue; i++) {
+            controller.enqueue('a');
+            enqueued++;
+          }
+          if (enqueued >= n) {
+            controller.close();
+          }
+        }
+      }, {
+        // Use buffer size as high water mark to allow pre-buffering
+        highWaterMark: bufferSize
+      });
+
+      let writes = 0;
+      const ws = new WritableStream({
+        write(_chunk) {
+          writes++;
+        }
+      });
+
+      await rs.pipeTo(ws);
+      assert.equal(writes, n);
+    }
+
+    for (const bufferSize of [1, 10, 100, 1000]) {
+      it(`of size ${bufferSize}`, () => test(bufferSize));
+    }
+  });
+});


### PR DESCRIPTION
When a `ReadableStream` already has (many) chunks buffered in its controller's queue, we know that `ReadableStreamDefaultReader.read()` will resolve synchronously. In this case, we can use `Promise.resolve()` to construct the result promise instead of doing `new Promise` and calling the `resolve` callback separately. https://github.com/nodejs/node/commit/199daab0b0822d6063a73b9362bfce8667d2a112 demonstrates that this can improve performance when repeatedly calling `read()` in a loop.

Similarly, piping from such a stream can be optimized by reading multiple chunks in a single "batch", as long as the destination is not applying backpressure. We also don't need to await the ready promise on every step of the pipe loop, we can check if there's backpressure synchronously (see https://github.com/nodejs/node/commit/f82525e9c854f15fa4e1da3fe02ec711d3f2fd74).

To do:
* [x] Add benchmarks