### PR TITLE
Harden CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,14 +17,14 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.release.target_commitish }}
       - name: Validate and extract release information
         id: release
-        uses: manovotny/github-releases-for-automated-package-publishing-action@v2.0.1
+        uses: manovotny/github-releases-for-automated-package-publishing-action@f8f252288da9babb174750562ce48fa5e5df70f5 # v2.0.1
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
-          cache: 'npm'
+          # Never trust the cache for release builds!
+          cache: ''
       - run: npm ci
       - name: Publish latest version
         if: steps.release.outputs.tag == ''

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,12 +18,12 @@ jobs:
       )
     steps:
       - name: Check out merge commit of pull request
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           submodules: true
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,11 +12,11 @@ jobs:
       !contains(github.event.head_commit.message, '[skip ci]')
     steps:
       - name: Check out commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: true
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -42,11 +42,11 @@ jobs:
       !contains(github.event.head_commit.message, '[skip ci]')
     steps:
       - name: Check out commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: true
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -65,11 +65,11 @@ jobs:
       !contains(github.event.head_commit.message, '[skip ci]')
     steps:
       - name: Check out commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: true
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -83,12 +83,12 @@ jobs:
         run: |
           npm run benchmark:read-buffered --workspace=test/benchmark-test | tee benchmark-read-buffered.txt
       - name: Download previous benchmark data
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark
       - name: 'Store benchmark result: queue size'
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1
         with:
           name: 'Queue size'
           tool: 'benchmarkjs'
@@ -98,7 +98,7 @@ jobs:
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Store benchmark result: buffered reads'
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1
         with:
           name: 'Buffered reads'
           tool: 'benchmarkjs'


### PR DESCRIPTION
* Pin all GitHub Actions to a full commit hash, [as recommended by GitHub](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions). This is now also [enforced at the repository level](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/).
* Set up Dependabot to keep all GitHub Actions up-to-date. This is especially important now that we're using commit hashes instead of version tags for these actions.
* Do not use the npm cache for release builds, to stop a potentially poisoned cache from infecting a published release. See [the TanStack postmortem](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem#2-github-actions-cache-poisoning-across-trust-boundaries) for details.